### PR TITLE
Update the server to run at VPS IP instead of 0.0.0.0

### DIFF
--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -37,7 +37,7 @@ func NewDNSServer(options *Options) (*DNSServer, error) {
 		timeToLive: 3600,
 	}
 	server.server = &dns.Server{
-		Addr:    "0.0.0.0:53",
+		Addr:    options.IPAddress+":53",
 		Net:     "udp",
 		Handler: server,
 	}


### PR DESCRIPTION
This update will run the server on the VPS IP instead of 0.0.0.0 solving the issue of running it on OS with systemd-resolved DNS servers.