### PR TITLE
Adding short tld/root domain support

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -26,7 +26,6 @@ var (
 	httpOnly     = flag.Bool("http-only", false, "Display only http requests in verbose output")
 	smtpOnly     = flag.Bool("smtp-only", false, "Display smtp interactions")
 	token        = flag.String("token", "", "Authentication token for the server")
-
 )
 
 const banner = `

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.IntVar(&eviction, "eviction", 7, "Number of days to persist interactions for")
 	flag.BoolVar(&options.Auth, "auth", false, "Require a token from the client to retrieve interactions")
 	flag.StringVar(&options.Token, "token", "", "Generate a token that the client must provide to retrieve interactions")
-	flag.BoolVar(&options.RootTLD, "root-tld", false, "Enable root tld")
+	flag.BoolVar(&options.RootTLD, "root-tld", false, "Enable support for *.domain.tld interaction")
 	flag.Parse()
 
 	if debug {

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.IntVar(&eviction, "eviction", 7, "Number of days to persist interactions for")
 	flag.BoolVar(&options.Auth, "auth", false, "Require a token from the client to retrieve interactions")
 	flag.StringVar(&options.Token, "token", "", "Generate a token that the client must provide to retrieve interactions")
-	flag.BoolVar(&options.ShortTLD, "short-tld", false, "Enable shortld")
+	flag.BoolVar(&options.RootTLD, "root-tld", false, "Enable root tld")
 	flag.Parse()
 
 	if debug {
@@ -40,8 +40,8 @@ func main() {
 		gologger.DefaultLogger.SetWriter(&noopWriter{})
 	}
 
-	// if short-tld is enabled we enable auth - This ensure that any client has the token
-	if options.ShortTLD {
+	// if root-tld is enabled we enable auth - This ensure that any client has the token
+	if options.RootTLD {
 		options.Auth = true
 	}
 	// of in case a custom token is specified
@@ -61,8 +61,8 @@ func main() {
 	store := storage.New(time.Duration(eviction) * time.Hour * 24)
 	options.Storage = store
 
-	// If short-tld is enabled create a singleton unencrypted record in the store
-	if options.ShortTLD {
+	// If riit-tld is enabled create a singleton unencrypted record in the store
+	if options.RootTLD {
 		_ = store.SetID(options.Domain)
 	}
 

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -31,6 +31,7 @@ func main() {
 	flag.IntVar(&eviction, "eviction", 7, "Number of days to persist interactions for")
 	flag.BoolVar(&options.Auth, "auth", false, "Require a token from the client to retrieve interactions")
 	flag.StringVar(&options.Token, "token", "", "Generate a token that the client must provide to retrieve interactions")
+	flag.BoolVar(&options.ShortTLD, "short-tld", false, "Enable shortld")
 	flag.Parse()
 
 	if debug {
@@ -39,9 +40,15 @@ func main() {
 		gologger.DefaultLogger.SetWriter(&noopWriter{})
 	}
 
+	// if short-tld is enabled we enable auth - This ensure that any client has the token
+	if options.ShortTLD {
+		options.Auth = true
+	}
+	// of in case a custom token is specified
 	if options.Token != "" {
 		options.Auth = true
 	}
+
 	if options.Auth && options.Token == "" {
 		b := make([]byte, 32)
 		if _, err := rand.Read(b); err != nil {
@@ -53,6 +60,11 @@ func main() {
 
 	store := storage.New(time.Duration(eviction) * time.Hour * 24)
 	options.Storage = store
+
+	// If short-tld is enabled create a singleton unencrypted record in the store
+	if options.ShortTLD {
+		store.SetID(options.Domain)
+	}
 
 	dnsServer, err := server.NewDNSServer(options)
 	if err != nil {

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	// If short-tld is enabled create a singleton unencrypted record in the store
 	if options.ShortTLD {
-		store.SetID(options.Domain)
+		_ = store.SetID(options.Domain)
 	}
 
 	dnsServer, err := server.NewDNSServer(options)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -153,6 +153,16 @@ func (c *Client) getInteractions(callback InteractionCallback) error {
 		}
 		callback(interaction)
 	}
+
+	// handle short-tld data if any
+	for _, data := range response.TLDData {
+		interaction := &server.Interaction{}
+		if err := jsoniter.UnmarshalFromString(data, interaction); err != nil {
+			gologger.Error().Msgf("Could not unmarshal interaction data interaction: %v\n", err)
+			continue
+		}
+		callback(interaction)
+	}
 	return nil
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -154,7 +154,7 @@ func (c *Client) getInteractions(callback InteractionCallback) error {
 		callback(interaction)
 	}
 
-	// handle short-tld data if any
+	// handle root-tld data if any
 	for _, data := range response.TLDData {
 		interaction := &server.Interaction{}
 		if err := jsoniter.UnmarshalFromString(data, interaction); err != nil {

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -88,8 +88,8 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		m.Ns = append(m.Ns, &dns.NS{Hdr: nsHeader, Ns: h.ns2Domain})
 	}
 
-	// if shorttld is enabled stores any interaction towards the main domain
-	if h.options.ShortTLD && strings.HasSuffix(domain, h.dotDomain) {
+	// if root-tld is enabled stores any interaction towards the main domain
+	if h.options.RootTLD && strings.HasSuffix(domain, h.dotDomain) {
 		correlationID := h.options.Domain
 		host, _, _ := net.SplitHostPort(w.RemoteAddr().String())
 		interaction := &Interaction{
@@ -104,10 +104,10 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		}
 		buffer := &bytes.Buffer{}
 		if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
-			gologger.Warning().Msgf("Could not encode shortld dns interaction: %s\n", err)
+			gologger.Warning().Msgf("Could not encode root tld dns interaction: %s\n", err)
 		} else {
-			gologger.Debug().Msgf("Short TLD DNS Interaction: \n%s\n", buffer.String())
-			if err := h.options.Storage.AddShortTLD(correlationID, buffer.Bytes()); err != nil {
+			gologger.Debug().Msgf("Root TLD DNS Interaction: \n%s\n", buffer.String())
+			if err := h.options.Storage.AddRootTLD(correlationID, buffer.Bytes()); err != nil {
 				gologger.Warning().Msgf("Could not store dns interaction: %s\n", err)
 			}
 		}

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -26,14 +26,14 @@ type DNSServer struct {
 
 // NewDNSServer returns a new DNS server.
 func NewDNSServer(options *Options) (*DNSServer, error) {
-	options.Domain = dns.Fqdn(options.Domain)
+	dotdomain := dns.Fqdn(options.Domain)
 	server := &DNSServer{
 		options:    options,
 		ipAddress:  net.ParseIP(options.IPAddress),
-		mxDomain:   "mail." + options.Domain,
-		ns1Domain:  "ns1." + options.Domain,
-		ns2Domain:  "ns2." + options.Domain,
-		dotDomain:  "." + options.Domain,
+		mxDomain:   "mail." + dotdomain,
+		ns1Domain:  "ns1." + dotdomain,
+		ns2Domain:  "ns2." + dotdomain,
+		dotDomain:  "." + dotdomain,
 		timeToLive: 3600,
 	}
 	server.server = &dns.Server{
@@ -84,10 +84,35 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		m.Answer = append(m.Answer, &dns.MX{Hdr: nsHdr, Mx: h.mxDomain, Preference: 1})
 	} else if r.Question[0].Qtype == dns.TypeNS {
 		nsHeader := dns.RR_Header{Name: domain, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: h.timeToLive}
-
 		m.Ns = append(m.Ns, &dns.NS{Hdr: nsHeader, Ns: h.ns1Domain})
 		m.Ns = append(m.Ns, &dns.NS{Hdr: nsHeader, Ns: h.ns2Domain})
 	}
+
+	// if shorttld is enabled stores any interaction towards the main domain
+	if h.options.ShortTLD && strings.HasSuffix(domain, h.dotDomain) {
+		correlationID := h.options.Domain
+		host, _, _ := net.SplitHostPort(w.RemoteAddr().String())
+		interaction := &Interaction{
+			Protocol:      "dns",
+			UniqueID:      domain,
+			FullId:        domain,
+			QType:         toQType(r.Question[0].Qtype),
+			RawRequest:    r.String(),
+			RawResponse:   m.String(),
+			RemoteAddress: host,
+			Timestamp:     time.Now(),
+		}
+		buffer := &bytes.Buffer{}
+		if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
+			gologger.Warning().Msgf("Could not encode shortld dns interaction: %s\n", err)
+		} else {
+			gologger.Debug().Msgf("Short TLD DNS Interaction: \n%s\n", buffer.String())
+			if err := h.options.Storage.AddShortTLD(correlationID, buffer.Bytes()); err != nil {
+				gologger.Warning().Msgf("Could not store dns interaction: %s\n", err)
+			}
+		}
+	}
+
 	if strings.HasSuffix(domain, h.dotDomain) {
 		parts := strings.Split(domain, ".")
 		for i, part := range parts {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -81,8 +81,8 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		w.WriteHeader(rec.Result().StatusCode)
 		_, _ = w.Write(data)
 
-		// if shorttld is enabled stores any interaction towards the main domain
-		if h.options.ShortTLD && strings.HasSuffix(r.Host, h.domain) {
+		// if root-tld is enabled stores any interaction towards the main domain
+		if h.options.RootTLD && strings.HasSuffix(r.Host, h.domain) {
 			ID := h.domain
 			host, _, _ := net.SplitHostPort(r.RemoteAddr)
 			interaction := &Interaction{
@@ -96,11 +96,11 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 			}
 			buffer := &bytes.Buffer{}
 			if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
-				gologger.Warning().Msgf("Could not encode shortld http interaction: %s\n", err)
+				gologger.Warning().Msgf("Could not encode root tld http interaction: %s\n", err)
 			} else {
-				gologger.Debug().Msgf("Short TLD DNS Interaction: \n%s\n", buffer.String())
-				if err := h.options.Storage.AddShortTLD(ID, buffer.Bytes()); err != nil {
-					gologger.Warning().Msgf("Could not store shortld http interaction: %s\n", err)
+				gologger.Debug().Msgf("Root TLD HTTP Interaction: \n%s\n", buffer.String())
+				if err := h.options.Storage.AddRootTLD(ID, buffer.Bytes()); err != nil {
+					gologger.Warning().Msgf("Could not store root tld http interaction: %s\n", err)
 				}
 			}
 		}
@@ -259,11 +259,11 @@ func (h *HTTPServer) pollHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var tlddata []string
-	if h.options.ShortTLD {
-		tlddata, err = h.options.Storage.GetShortTLDInteractions(h.options.Domain)
+	if h.options.RootTLD {
+		tlddata, err = h.options.Storage.GetRootTLDInteractions(h.options.Domain)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			gologger.Warning().Msgf("Could not get short-tld interactions for %s: %s\n", h.options.Domain, err)
+			gologger.Warning().Msgf("Could not get root-tld interactions for %s: %s\n", h.options.Domain, err)
 			jsonError(w, errors.Wrap(err, "could not get interactions"), http.StatusBadRequest)
 			return
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,8 +44,9 @@ type Options struct {
 	// Auth requires client to authenticate
 	Auth bool
 	// Token required to retrieve interactions
-	Token    string
-	ShortTLD bool
+	Token string
+	// Enable root tld interactions
+	RootTLD bool
 }
 
 // URLReflection returns a reversed part of the URL payload

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,7 +44,8 @@ type Options struct {
 	// Auth requires client to authenticate
 	Auth bool
 	// Token required to retrieve interactions
-	Token string
+	Token    string
+	ShortTLD bool
 }
 
 // URLReflection returns a reversed part of the URL payload

--- a/pkg/server/smtp_server.go
+++ b/pkg/server/smtp_server.go
@@ -82,6 +82,33 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 
 	gologger.Debug().Msgf("New SMTP request: %s %s %s %s\n", remoteAddr, from, to, string(data))
 
+	// if shorttld is enabled stores any interaction towards the main domain
+	for _, addr := range to {
+		if h.options.ShortTLD && strings.HasSuffix(addr, h.options.Domain) {
+			ID := h.options.Domain
+			host, _, _ := net.SplitHostPort(remoteAddr.String())
+			address := addr[strings.Index(addr, "@"):]
+			interaction := &Interaction{
+				Protocol:      "smtp",
+				UniqueID:      address,
+				FullId:        address,
+				RawRequest:    string(data),
+				SMTPFrom:      from,
+				RemoteAddress: host,
+				Timestamp:     time.Now(),
+			}
+			buffer := &bytes.Buffer{}
+			if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
+				gologger.Warning().Msgf("Could not encode shortld http interaction: %s\n", err)
+			} else {
+				gologger.Debug().Msgf("Short TLD DNS Interaction: \n%s\n", buffer.String())
+				if err := h.options.Storage.AddShortTLD(ID, buffer.Bytes()); err != nil {
+					gologger.Warning().Msgf("Could not store shortld http interaction: %s\n", err)
+				}
+			}
+		}
+	}
+
 	for _, addr := range to {
 		if len(addr) > 33 && strings.Contains(addr, "@") {
 			parts := strings.Split(addr[strings.Index(addr, "@")+1:], ".")

--- a/pkg/server/smtp_server.go
+++ b/pkg/server/smtp_server.go
@@ -82,9 +82,9 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 
 	gologger.Debug().Msgf("New SMTP request: %s %s %s %s\n", remoteAddr, from, to, string(data))
 
-	// if shorttld is enabled stores any interaction towards the main domain
+	// if root-tld is enabled stores any interaction towards the main domain
 	for _, addr := range to {
-		if h.options.ShortTLD && strings.HasSuffix(addr, h.options.Domain) {
+		if h.options.RootTLD && strings.HasSuffix(addr, h.options.Domain) {
 			ID := h.options.Domain
 			host, _, _ := net.SplitHostPort(remoteAddr.String())
 			address := addr[strings.Index(addr, "@"):]
@@ -99,11 +99,11 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 			}
 			buffer := &bytes.Buffer{}
 			if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
-				gologger.Warning().Msgf("Could not encode shortld http interaction: %s\n", err)
+				gologger.Warning().Msgf("Could not encode root tld SMTP interaction: %s\n", err)
 			} else {
-				gologger.Debug().Msgf("Short TLD DNS Interaction: \n%s\n", buffer.String())
-				if err := h.options.Storage.AddShortTLD(ID, buffer.Bytes()); err != nil {
-					gologger.Warning().Msgf("Could not store shortld http interaction: %s\n", err)
+				gologger.Debug().Msgf("Root TLD SMTP Interaction: \n%s\n", buffer.String())
+				if err := h.options.Storage.AddRootTLD(ID, buffer.Bytes()); err != nil {
+					gologger.Warning().Msgf("Could not store root tld smtp interaction: %s\n", err)
 				}
 			}
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -101,8 +101,8 @@ func (s *Storage) AddInteraction(correlationID string, data []byte) error {
 	return nil
 }
 
-func (s *Storage) AddShortTLD(shortTLD string, data []byte) error {
-	item := s.cache.Get(shortTLD)
+func (s *Storage) AddRootTLD(rootTLD string, data []byte) error {
+	item := s.cache.Get(rootTLD)
 	if item == nil {
 		return errors.New("could not get correlation-id from cache")
 	}
@@ -138,7 +138,7 @@ func (s *Storage) GetInteractions(correlationID, secret string) ([]string, strin
 	return data, value.AESKey, nil
 }
 
-func (s *Storage) GetShortTLDInteractions(ID string) ([]string, error) {
+func (s *Storage) GetRootTLDInteractions(ID string) ([]string, error) {
 	item := s.cache.Get(ID)
 	if item == nil {
 		return nil, errors.New("could not get id from cache")

--- a/pkg/stringslice/stringslice.go
+++ b/pkg/stringslice/stringslice.go
@@ -1,0 +1,14 @@
+package stringslice
+
+import "strings"
+
+type StringSlice []string
+
+func (i *StringSlice) String() string {
+	return strings.Join(*i, " ")
+}
+
+func (stringSlice *StringSlice) Set(value string) error {
+	*stringSlice = append(*stringSlice, value)
+	return nil
+}


### PR DESCRIPTION
Server:

```
./interactsh-server -domain hackwithautomation.com -hostmaster admin@hackwithautomation.com -ip X.X.X.X -listen-ip X.X.X.X -root-tld
```

Client:

```
./interactsh-client -token XXXX

[canyouseeme.hackwithautomation.com.] Received DNS interaction (A) from 49.45.31.132 at 2021-08-28 20:47:36
[canyouseeme.hackwithautomation.com.] Received DNS interaction (A) from 49.45.31.132 at 2021-08-28 20:47:36
[canyouseeme.hackwithautomation.com] Received HTTP interaction from 49.36.108.46 at 2021-08-28 20:47:36
[canyouseeme.hackwithautomation.com] Received HTTP interaction from 49.36.108.46 at 2021-08-28 20:47:36
[canyouseeme.hackwithautomation.com] Received HTTP interaction from 49.36.108.46 at 2021-08-28 20:47:36
```
