### PR TITLE
Fix broken dependency blocks install nuclei

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/retryablehttp-go v1.0.1
-	github.com/prologic/smtpd v0.0.0-20210126001904-0893ad18168e
+	github.com/mhale/smtpd v0.0.0-20210126001904-0893ad18168e
 	github.com/rs/xid v1.3.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/corvus-ch/zbase32.v1 v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/retryablehttp-go v1.0.1
-	github.com/mhale/smtpd v0.0.0-20210126001904-0893ad18168e
+	github.com/mhale/smtpd v0.0.0-20210322105601-438c8edb069c
 	github.com/rs/xid v1.3.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/corvus-ch/zbase32.v1 v1.0.0


### PR DESCRIPTION
Hey there!

```
root@nuclei:~# GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei

go get: github.com/projectdiscovery/nuclei/v2@v2.4.2 requires
	github.com/projectdiscovery/interactsh@v0.0.3 requires
	github.com/prologic/smtpd@v0.0.0-20210126001904-0893ad18168e: invalid version: git fetch -f https://github.com/prologic/smtpd refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /root/go/pkg/mod/cache/vcs/65b3100cfa8e2061b6047e41aaceb4a1e850f70977a718cfde5bd0e009bb0722: exit status 128:
	fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

```
curl https://github.com/prologic/smtpd -I
HTTP/2 404
server: GitHub.com
date: Mon, 09 Aug 2021 08:49:03 GMT
...
```

I just look around and mhale's repo looks like original: https://github.com/mhale/smtpd (https://github.com/mhale/smtpd/commit/0893ad18168e5bade1e0c446a484340ff652317c).