### PR TITLE
Fix hyperlink in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="#running-interactsh-client">Interactsh Client</a> •
   <a href="#setting-up-self-hosted-instance">Interactsh Server</a> •
   <a href="#burp-suite-extension">Burp Suite Extension</a> •
-  <a href="#owasp-zap-addon">OWASP ZAP Add-on</a> •
+  <a href="#owasp-zap-add-on">OWASP ZAP Add-on</a> •
   <a href="https://discord.gg/projectdiscovery">Join Discord</a>
 </p>
 


### PR DESCRIPTION
Just noticed that the internal hyperlink was incorrect, my bad.

Signed-off-by: ricekot <ricekot@gmail.com>