### PR TITLE
DNS: Case-Insensitive domain name (#75)

### DIFF
--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -64,7 +64,7 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	requestMsg := r.String()
 
 	gologger.Debug().Msgf("New DNS request: %s\n", requestMsg)
-	domain := m.Question[0].Name
+	domain := strings.ToLower(m.Question[0].Name)
 
 	var uniqueID, fullID string
 


### PR DESCRIPTION
I had the issue described in #75: Curl and nslookup over a third-party DNS-server didn't show up in the client. The following was logged:

```
[DBG] New DNS request: ;; opcode: QUERY, status: NOERROR, id: 40634
;; flags: cd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; QUESTION SECTION:
;C6rodgUPmJ9NmjpRCpbgCg5aptYyyYYYN.d.[XXX].	IN	 A

;; ADDITIONAL SECTION:

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: do; udp: 4096
```

After the change all DNS requests are logged and shown in the client.