### PR TITLE
Parse SearchRequest and build Interaction object

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -122,7 +122,7 @@ func main() {
 				}
 			case "ldap":
 				if noFilter {
-					builder.WriteString(fmt.Sprintf("Received LDAP interaction from %s at %s", interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05")))
+					builder.WriteString(fmt.Sprintf("[%s] Received LDAP interaction from %s at %s", interaction.FullId, interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05")))
 					if *verbose {
 						builder.WriteString(fmt.Sprintf("\n------------\nLDAP Interaction\n------------\n\n%s\n\n", interaction.RawRequest))
 					}

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -108,17 +108,14 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	res := ldap.NewSearchResultDoneResponse(ldap.LDAPResultSuccess)
 	w.Write(res)
 
-	// For CVE-2021-44228, an incoming request will be formatted like the path part of a URI, e.g.:
+	// BaseObject will be formatted like the path part of a URI, e.g.:
 	//   path/to/malicious.class
-	// If a user injects on this, their collab/interact url could be in any part of it
-	// What if it's encoded?
 	domain := strings.ReplaceAll(ldapServer.options.Domain, ".", "\\.")
-	// This will attempt to match the unique ID and the interact server's configured domain, e.g.:
+	// Regex pattern will attempt to match the unique ID and the interact server's configured domain, e.g.:
 	//   abcd1234.interact.sh
 	re, _ := regexp.Compile("(?:[a-z0-9\\-]+)\\." + domain)
 	match := re.FindString(string(r.BaseObject()))
 	if match != "" {
-		//if strings.Contains(string(r.BaseObject()), ldapServer.options.Domain) {
 		parts = strings.Split(match, ".")
 	}
 


### PR DESCRIPTION
The changes here will parse SearchRequest's BaseObject for the interactsh server and construct an Interaction object to be used for request correlation.