### PR TITLE
Issue 141 - Lowercase FQDNs in responses

### DIFF
--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -64,7 +64,7 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	requestMsg := r.String()
 
 	gologger.Debug().Msgf("New DNS request: %s\n", requestMsg)
-	domain := m.Question[0].Name
+	domain := strings.ToLower(m.Question[0].Name)
 
 	var uniqueID, fullID string
 


### PR DESCRIPTION
systemd reolve break case of domain name. So i force domain to be in lower case to solve it. No side effect with ID because it is always lowercase #141 

original domain :
`c726z4w2vtc000002bc0gdtdsdeyyyyyk.dns.exemple.com`

system try to resolv :
`C726z4W2Vtc000002BC0gDtDsdeYYyYYK.DnS2.eXeMPle.com`