### PR TITLE
Adding optional support for HTTP fallback on HTTPS failure

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -44,6 +44,7 @@ func main() {
 	httpOnly := flag.Bool("http-only", false, "Display only http interaction in CLI output")
 	smtpOnly := flag.Bool("smtp-only", false, "Display only smtp interactions in CLI output")
 	token := flag.String("token", "", "Authentication token to connect interactsh server")
+	disableHttpFallback := flag.Bool("no-http-fallback", false, "Disable http fallback")
 
 	flag.Parse()
 
@@ -62,6 +63,7 @@ func main() {
 		ServerURL:         *serverURL,
 		PersistentSession: *persistent,
 		Token:             *token,
+		HTTPFallback:      !*disableHttpFallback,
 	})
 	if err != nil {
 		gologger.Fatal().Msgf("Could not create client: %s\n", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -54,6 +54,8 @@ type Options struct {
 	PersistentSession bool
 	// Token if the server requires authentication
 	Token string
+	// HTTPFallback determines if failed requests over https should be retried over http
+	HTTPFallback bool
 }
 
 // New creates a new client instance based on provided options
@@ -71,8 +73,13 @@ func New(options *Options) (*Client, error) {
 		httpClient:        retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle),
 		token:             options.Token,
 	}
+gen_keys:
 	// Generate an RSA Public / Private key for interactsh client
 	if err := client.generateRSAKeyPair(); err != nil {
+		if options.HTTPFallback && parsed.Scheme == "https" {
+			parsed.Scheme = "http"
+			goto gen_keys
+		}
 		return nil, err
 	}
 	return client, nil


### PR DESCRIPTION
This PR adds support for automatic retry over http in case of https failure for `interactsh-client`. The behavior can be disabled with the CLI option `-no-http-fallback`.
A new option flag, `HTTPFallback` (disabled by default), enables the described behavior when using the client as a library.