### PR TITLE
Making app CNAME optional

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -51,6 +51,7 @@ func main() {
 	flag.BoolVar(&options.RootTLD, "root-tld", false, "Enable wildcard/global interaction for *.domain.com")
 	flag.StringVar(&options.FTPDirectory, "ftp-dir", "", "Ftp directory - temporary if not specified")
 	flag.BoolVar(&skipacme, "skip-acme", false, "Skip acme registration (certificate checks/handshake + TLS protocols will be disabled)")
+	flag.BoolVar(&options.AppCnameDNSRecord, "app-cname", false, "Enable DNS CNAME record (eg. app.interactsh.domain) for web app")
 	flag.Parse()
 
 	if options.IPAddress == "" && options.ListenIP == "0.0.0.0" {

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -105,7 +105,7 @@ func (h *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 			handleClould(net.ParseIP("169.254.169.254"))
 		case strings.EqualFold(domain, "alibaba"+h.dotDomain):
 			handleClould(net.ParseIP("100.100.100.200"))
-		case strings.EqualFold(domain, "app"+h.dotDomain):
+		case h.options.AppCnameDNSRecord && strings.EqualFold(domain, "app"+h.dotDomain):
 			handleAppWithCname("projectdiscovery.github.io", net.ParseIP("185.199.108.153"), net.ParseIP("185.199.110.153"), net.ParseIP("185.199.111.153"), net.ParseIP("185.199.108.153"))
 		default:
 			handleClould(h.ipAddress)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,9 @@ type Options struct {
 	OriginURL string
 	// FTPDirectory or temporary one
 	FTPDirectory string
+	// AppCnameDNSRecord determines if the dns server returns CNAME record
+	// similar to app.interactsh.domain
+	AppCnameDNSRecord bool
 }
 
 // URLReflection returns a reversed part of the URL payload


### PR DESCRIPTION
## Description
This PR disables, by default, the CNAME record for the web app. The newly introduced flag (`-app-cname`) controls the behavior.

## Reproduction Steps
- `interactsh-server` with cname disabled (default behavior):
```console
$ sudo go run . -listen-ip 192.168.1.9 -skip-acme -debug -domain example -debug
```
- `interactsh-server` with cname enabled:
```console
$ sudo go run . -listen-ip 192.168.1.9 -skip-acme -debug -domain example -debug -app-cname
```