### PR TITLE
Added random server pickup + misc changes to client

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -31,9 +31,10 @@ func showBanner() {
 }
 
 func main() {
+	defaultOpts := client.DefaultOptions
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	serverURL := flag.String("server", "https://interact.sh", "Interactsh server to use")
+	serverURL := flag.String("server", defaultOpts.ServerURL, "Interactsh server(s) to use")
 	n := flag.Int("n", 1, "Interactsh payload count to generate")
 	output := flag.String("o", "", "Output file to write interaction")
 	json := flag.Bool("json", false, "Write output in JSONL(ines) format")
@@ -60,10 +61,10 @@ func main() {
 	}
 
 	client, err := client.New(&client.Options{
-		ServerURL:         *serverURL,
-		PersistentSession: *persistent,
-		Token:             *token,
-		HTTPFallback:      !*disableHttpFallback,
+		ServerURL:           *serverURL,
+		PersistentSession:   *persistent,
+		Token:               *token,
+		DisableHTTPFallback: *disableHttpFallback,
 	})
 	if err != nil {
 		gologger.Fatal().Msgf("Could not create client: %s\n", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	mathrand "math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -36,14 +37,15 @@ var objectIDCounter = uint32(0)
 
 // Client is a client for communicating with interactsh server instance.
 type Client struct {
-	correlationID     string
-	secretKey         string
-	serverURL         *url.URL
-	httpClient        *retryablehttp.Client
-	privKey           *rsa.PrivateKey
-	quitChan          chan struct{}
-	persistentSession bool
-	token             string
+	correlationID       string
+	secretKey           string
+	serverURL           *url.URL
+	httpClient          *retryablehttp.Client
+	privKey             *rsa.PrivateKey
+	quitChan            chan struct{}
+	persistentSession   bool
+	disableHTTPFallback bool
+	token               string
 }
 
 // Options contains configuration options for interactsh client
@@ -54,39 +56,134 @@ type Options struct {
 	PersistentSession bool
 	// Token if the server requires authentication
 	Token string
-	// HTTPFallback determines if failed requests over https should be retried over http
-	HTTPFallback bool
+	// DisableHTTPFallback determines if failed requests over https should not be retried over http
+	DisableHTTPFallback bool
+}
+
+// DefaultOptions is the default options for the interact client
+var DefaultOptions = &Options{
+	ServerURL: "interact.sh,interactsh.com",
 }
 
 // New creates a new client instance based on provided options
 func New(options *Options) (*Client, error) {
-	parsed, err := url.Parse(options.ServerURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not parse server URL")
-	}
+	mathrand.Seed(time.Now().UnixNano())
+
 	opts := retryablehttp.DefaultOptionsSingle
-	opts.Timeout = 15 * time.Second
+	opts.Timeout = 10 * time.Second
 
 	// Generate a random ksuid which will be used as server secret.
 	client := &Client{
-		serverURL:         parsed,
-		secretKey:         uuid.New().String(), // uuid as more secure
-		correlationID:     xid.New().String(),
-		persistentSession: options.PersistentSession,
-		httpClient:        retryablehttp.NewClient(opts),
-		token:             options.Token,
+		secretKey:           uuid.New().String(), // uuid as more secure
+		correlationID:       xid.New().String(),
+		persistentSession:   options.PersistentSession,
+		httpClient:          retryablehttp.NewClient(opts),
+		token:               options.Token,
+		disableHTTPFallback: options.DisableHTTPFallback,
+	}
+	payload, err := client.initializeRSAKeys()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not initialize rsa keys")
 	}
 
-gen_keys:
-	// Generate an RSA Public / Private key for interactsh client
-	if err := client.generateRSAKeyPair(); err != nil {
-		if options.HTTPFallback && parsed.Scheme == "https" {
-			parsed.Scheme = "http"
-			goto gen_keys
-		}
-		return nil, err
+	if err := client.parseServerURLs(options.ServerURL, payload); err != nil {
+		return nil, errors.Wrap(err, "could not register to servers")
 	}
 	return client, nil
+}
+
+// initializeRSAKeys does the one-time initialization for RSA crypto mechanism
+// and returns the data payload for the client.
+func (c *Client) initializeRSAKeys() ([]byte, error) {
+	// Generate a 2048-bit private-key
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not generate rsa private key")
+	}
+	c.privKey = priv
+	pub := priv.Public()
+
+	pubkeyBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal public key")
+	}
+	pubkeyPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: pubkeyBytes,
+	})
+
+	encoded := base64.StdEncoding.EncodeToString(pubkeyPem)
+	register := server.RegisterRequest{
+		PublicKey:     encoded,
+		SecretKey:     c.secretKey,
+		CorrelationID: c.correlationID,
+	}
+	data, err := jsoniter.Marshal(register)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal register request")
+	}
+	return data, nil
+}
+
+// parseServerURLs parses server url string. Multiple URLs are supported
+// comma separated and a random one will be used on runtime.
+//
+// If the https scheme is not working, http is tried. url can be comma separated
+// domains or full urls as well.
+//
+// If the first picked random domain doesn't work, the list of domains is iterated
+// after being shuffled.
+func (c *Client) parseServerURLs(serverURL string, payload []byte) error {
+	if serverURL == "" {
+		return errors.New("invalid server url provided")
+	}
+
+	values := strings.Split(serverURL, ",")
+	firstIdx := mathrand.Intn(len(values))
+	gotValue := values[firstIdx]
+
+	registerFunc := func(got string) error {
+		if !strings.HasPrefix(got, "http") {
+			got = "https://" + got
+		}
+		parsed, err := url.Parse(got)
+		if err != nil {
+			return errors.Wrap(err, "could not parse server URL")
+		}
+	makeReq:
+		if err := c.performRegistration(parsed.String(), payload); err != nil {
+			if !c.disableHTTPFallback && parsed.Scheme == "https" {
+				parsed.Scheme = "http"
+				gologger.Error().Msgf("Could not register to %s: %s, retrying with http\n", parsed.String(), err)
+				goto makeReq
+			}
+			return err
+		}
+		c.serverURL = parsed
+		return nil
+	}
+	err := registerFunc(gotValue)
+	if err != nil {
+		gologger.Error().Msgf("Could not register to %s: %s, retrying with remaining\n", gotValue, err)
+		values = removeIndex(values, firstIdx)
+		mathrand.Shuffle(len(values), func(i, j int) { values[i], values[j] = values[j], values[i] })
+
+		for _, value := range values {
+			if err = registerFunc(value); err != nil {
+				gologger.Error().Msgf("Could not register to %s: %s, retrying with remaining\n", gotValue, err)
+				continue
+			}
+			break
+		}
+	}
+	if c.serverURL != nil {
+		return nil
+	}
+	return err // return errors if any.
+}
+
+func removeIndex(s []string, index int) []string {
+	return append(s[:index], s[index+1:]...)
 }
 
 // InteractionCallback is a callback function for a reported interaction
@@ -235,43 +332,15 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// generateRSAKeyPair generates an RSA public-private keypair and
-// registers the current client with the master server using the
+// performRegistration registers the current client with the master server using the
 // provided RSA Public Key as well as Correlation Key.
-func (c *Client) generateRSAKeyPair() error {
-	// Generate a 2048-bit private-key
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return errors.Wrap(err, "could not generate rsa private key")
-	}
-	c.privKey = priv
-	pub := priv.Public()
-
-	pubkeyBytes, err := x509.MarshalPKIXPublicKey(pub)
-	if err != nil {
-		return errors.Wrap(err, "could not marshal public key")
-	}
-	pubkeyPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PUBLIC KEY",
-		Bytes: pubkeyBytes,
-	})
-
-	encoded := base64.StdEncoding.EncodeToString(pubkeyPem)
-	register := server.RegisterRequest{
-		PublicKey:     encoded,
-		SecretKey:     c.secretKey,
-		CorrelationID: c.correlationID,
-	}
-	data, err := jsoniter.Marshal(register)
-	if err != nil {
-		return errors.Wrap(err, "could not marshal register request")
-	}
-	URL := c.serverURL.String() + "/register"
-	req, err := retryablehttp.NewRequest("POST", URL, bytes.NewReader(data))
+func (c *Client) performRegistration(serverURL string, payload []byte) error {
+	URL := serverURL + "/register"
+	req, err := retryablehttp.NewRequest("POST", URL, bytes.NewReader(payload))
 	if err != nil {
 		return errors.Wrap(err, "could not create new request")
 	}
-	req.ContentLength = int64(len(data))
+	req.ContentLength = int64(len(payload))
 
 	if c.token != "" {
 		req.Header.Add("Authorization", c.token)


### PR DESCRIPTION
This PR adds support for random interact server selection from a comma separated list as mentioned in #170.

Sample run

```
    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ v0.0.8-dev

                projectdiscovery.io

[ERR] Could not register to interactsh.com: could not make register request: POST https://interactsh.com/register giving up after 6 attempts: Post "https://interactsh.com/register": dial tcp 104.248.51.21:443: connect: connection refused, retrying with remaining
[INF] Listing 1 payload for OOB Testing
[INF] c7dm5q2ciaemkkf4e3t0c8psf7yyyyyyn.interact.sh
```