### PR TITLE
Fix ANY queries and TCP socket for DNS

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -97,15 +97,15 @@ func main() {
 		_ = store.SetID(options.Domain)
 	}
 
-	dnsServer, err := server.NewDNSServer(options)
-	if err != nil {
-		gologger.Fatal().Msgf("Could not create DNS server")
-	}
-	go dnsServer.ListenAndServe()
+	TCPDNSServer := server.NewDNSServer("tcp", options)
+	UDPDNSServer := server.NewDNSServer("udp", options)
+	go TCPDNSServer.ListenAndServe()
+	go UDPDNSServer.ListenAndServe()
 
 	trimmedDomain := strings.TrimSuffix(options.Domain, ".")
 	autoTLS, err := acme.NewAutomaticTLS(options.Hostmaster, fmt.Sprintf("*.%s,%s", trimmedDomain, trimmedDomain), func(txt string) {
-		dnsServer.TxtRecord = txt
+		TCPDNSServer.TxtRecord = txt
+		UDPDNSServer.TxtRecord = txt
 	})
 	if err != nil {
 		gologger.Warning().Msgf("An error occurred while applying for an certificate, error: %v", err)

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -25,7 +25,7 @@ type DNSServer struct {
 }
 
 // NewDNSServer returns a new DNS server.
-func NewDNSServer(options *Options) (*DNSServer, error) {
+func NewDNSServer(network string, options *Options) (*DNSServer) {
 	dotdomain := dns.Fqdn(options.Domain)
 	server := &DNSServer{
 		options:    options,
@@ -38,16 +38,16 @@ func NewDNSServer(options *Options) (*DNSServer, error) {
 	}
 	server.server = &dns.Server{
 		Addr:    options.ListenIP + ":53",
-		Net:     "udp",
+		Net:     network,
 		Handler: server,
 	}
-	return server, nil
+	return server
 }
 
 // ListenAndServe listens on dns ports for the server.
 func (h *DNSServer) ListenAndServe() {
 	if err := h.server.ListenAndServe(); err != nil {
-		gologger.Error().Msgf("Could not serve dns on port 53: %s\n", err)
+		gologger.Fatal().Msgf("Could not listen for %s DNS on %s (%s)\n", h.server.Net, h.server.Addr, err)
 	}
 }
 


### PR DESCRIPTION
Sets up both TCP and UDP DNS servers, which should allow for the occasional case where a TCP query can make it to the server but UDP can't, and fixes support for ANY queries. ANY queries are deprecated in RFC8482 but this may also provide for additional interaction opportunities.

Re-organises the error handling around DNS server creation slightly because `error` was always returned as `nil` anyway.