### PR TITLE
Improve default socket listening behaviour

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -30,7 +30,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "Run interactsh in debug mode")
 	flag.StringVar(&options.Domain, "domain", "", "Domain to use for interactsh server")
 	flag.StringVar(&options.IPAddress, "ip", "", "Public IP Address to use for interactsh server")
-	flag.StringVar(&options.ListenIP, "listen-ip", "0.0.0.0", "Public IP Address to listen on")
+	flag.StringVar(&options.ListenIP, "listen-ip", "", "IP Address to listen on")
 	flag.StringVar(&options.Hostmaster, "hostmaster", "", "Hostmaster email to use for interactsh server")
 	flag.IntVar(&eviction, "eviction", 30, "Number of days to persist interactions for")
 	flag.BoolVar(&responder, "responder", false, "Start a responder agent - docker must be installed")
@@ -41,10 +41,9 @@ func main() {
 	flag.BoolVar(&options.RootTLD, "root-tld", false, "Enable wildcard/global interaction for *.domain.com")
 	flag.Parse()
 
-	if options.IPAddress == "" && options.ListenIP == "0.0.0.0" {
+	if options.IPAddress == "" {
 		ip := getPublicIP()
 		options.IPAddress = ip
-		options.ListenIP = ip
 	}
 	if options.Hostmaster == "" {
 		options.Hostmaster = fmt.Sprintf("admin@%s", options.Domain)


### PR DESCRIPTION
This commit fixes two issues:

- Previously if a "listen IP" wasn't specified the public IP looked up from cloud metadata was used. In many cases cloud VMs do not have their "public" IP bound to an interface (such as Amazon EC2), causing startup to fail:
  ```
  $ ./interactsh-server -domain example.com
  [FTL] Could not listen for udp DNS on 203.0.113.42:53 (listen udp 203.0.113.42:53: bind: cannot assign requested address)
  ```
  This has been changed to by default bind to an appropriate wildcard address, which should work in basically all cases.

- The default wildcard listen address has been changed to `:<port number>`, which will cause the socket to pick a suitable wildcard address depending on whether the machine is dual stack or IPv4-only. This further supports upcoming work to add IPv6 support.