### PR TITLE
Fix ANY queries and TCP socket for DNS

### DIFF
--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -27,7 +27,7 @@ type DNSServer struct {
 }
 
 // NewDNSServer returns a new DNS server.
-func NewDNSServer(options *Options) (*DNSServer, error) {
+func NewDNSServer(network string, options *Options) (*DNSServer) {
 	dotdomain := dns.Fqdn(options.Domain)
 	server := &DNSServer{
 		options:    options,
@@ -40,17 +40,17 @@ func NewDNSServer(options *Options) (*DNSServer, error) {
 	}
 	server.server = &dns.Server{
 		Addr:    options.ListenIP + fmt.Sprintf(":%d", options.DnsPort),
-		Net:     "udp",
+		Net:     network,
 		Handler: server,
 	}
-	return server, nil
+	return server
 }
 
 // ListenAndServe listens on dns ports for the server.
 func (h *DNSServer) ListenAndServe(dnsAlive chan bool) {
 	dnsAlive <- true
 	if err := h.server.ListenAndServe(); err != nil {
-		gologger.Error().Msgf("Could not serve dns on port %d: %s\n", h.options.DnsPort, err)
+		gologger.Error().Msgf("Could not listen for %s DNS on %s (%s)\n", strings.ToUpper(h.server.Net), h.server.Addr, err)
 		dnsAlive <- false
 	}
 }


### PR DESCRIPTION
Sets up both TCP and UDP DNS servers, which should allow for the occasional case where a TCP query can make it to the server but UDP can't, and fixes support for ANY queries. ANY queries are deprecated in RFC8482 but this may also provide for additional interaction opportunities.

Re-organises the error handling around DNS server creation slightly because `error` was always returned as `nil` anyway.