### PR TITLE
Implement IPv6 support for DNS, fix some DNS server behaviours

### DIFF
--- a/pkg/server/responder_server.go
+++ b/pkg/server/responder_server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,17 +25,13 @@ var responderMonitorList map[string]string = map[string]string{
 type ResponderServer struct {
 	options   *Options
 	LogFile   string
-	ipAddress net.IP
 	cmd       *exec.Cmd
 	tmpFolder string
 }
 
 // NewResponderServer returns a new SMB server.
 func NewResponderServer(options *Options) (*ResponderServer, error) {
-	server := &ResponderServer{
-		options:   options,
-		ipAddress: net.ParseIP(options.IPAddress),
-	}
+	server := &ResponderServer{options: options}
 	return server, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net"
 	"strings"
 	"time"
 
@@ -34,8 +35,8 @@ type Interaction struct {
 type Options struct {
 	// Domain is the domain for the instance.
 	Domain string
-	// IPAddress is the IP address of the current server.
-	IPAddress string
+	// IPAddresses is a slice of net.IPs that should be returned in DNS (IPv4 and IPv6) responses. Generally one of each.
+	IPAddresses []net.IP
 	// ListenIP is the IP address to listen servers on
 	ListenIP string
 	// DomainPort is the port to listen DNS servers on

--- a/pkg/server/smb_server.go
+++ b/pkg/server/smb_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -26,17 +25,13 @@ var smbMonitorList map[string]string = map[string]string{
 type SMBServer struct {
 	options   *Options
 	LogFile   string
-	ipAddress net.IP
 	cmd       *exec.Cmd
 	tmpFile   string
 }
 
 // NewSMBServer returns a new SMB server.
 func NewSMBServer(options *Options) (*SMBServer, error) {
-	server := &SMBServer{
-		options:   options,
-		ipAddress: net.ParseIP(options.IPAddress),
-	}
+	server := &SMBServer{options: options}
 	return server, nil
 }
 


### PR DESCRIPTION
This commit allows the DNS server to serve IPv6 address records (AAAA) for both interaction and NS glue. In combination with the changes in #181 and #182 this allows for IPv6 interaction and provides more opportunities for interaction to ocurr when e.g. IPv6 and IPv4 egress firewalling differ on a network being tested.

Specifying the '-ip' option multiple times now allows setting multiple response addresses for the DNS server. Both IPv4 and IPv6 addresses are supported. If no IP address is specified the auto-detected address will be logged at startup time to aid with troubleshooting.

Fixes a couple of behaviour bugs with the DNS server implementation and changes the default TTL to `5` from `3600`.