### PR TITLE
Fix IpAddress (incorrectly) being set to ListenIpAddress

### DIFF
--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -34,7 +34,7 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 	return &server.Options{
 		Domain:          cliServerOptions.Domain,
 		DnsPort:         cliServerOptions.DnsPort,
-		IPAddress:       cliServerOptions.ListenIP,
+		IPAddress:       cliServerOptions.IPAddress,
 		ListenIP:        cliServerOptions.ListenIP,
 		HttpPort:        cliServerOptions.HttpPort,
 		HttpsPort:       cliServerOptions.HttpsPort,


### PR DESCRIPTION
IpAddress was (incorrectly) set to ListenIpAddress.
This pull request fixes issue #200.

I just tested this fix on a server behind NAT and it indeed resolves the issue (everything is working as expected).