### PR TITLE
Fix banner text

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -155,7 +155,7 @@ const banner = `<h1> Interactsh Server </h1>
 
 <a href='https://github.com/projectdiscovery/interactsh'><b>Interactsh</b></a> is an open-source tool for detecting out-of-band interactions. It is a tool designed to detect vulnerabilities that cause external interactions.<br><br>
 
-If you notice any interactions from <b>*.%s</b> percent s in your logs, it's possible that someone (internal security engineers, pen-testers, bug-bounty hunters) has been testing your application.<br><br>
+If you notice any interactions from <b>*.%s</b> in your logs, it's possible that someone (internal security engineers, pen-testers, bug-bounty hunters) has been testing your application.<br><br>
 
 You should investigate the sites where these interactions were generated from, and if a vulnerability exists, examine the root cause and take the necessary steps to mitigate the issue.
 `


### PR DESCRIPTION
This pull request removes literal "percent s" from the banner text (see the screenshot below for the issue).

![Screenshot showing the current banner text contaning the erroneous text](https://user-images.githubusercontent.com/22079593/150798224-a836f4c1-4880-423b-a0c0-44357de4ca61.png)
