### PR TITLE
Making correlationid length parametrizable

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -32,6 +32,8 @@ func main() {
 		flagSet.IntVarP(&cliOptions.PollInterval, "poll-interval", "pi", 5, "poll interval in seconds to pull interaction data"),
 		flagSet.BoolVarP(&cliOptions.DisableHTTPFallback, "no-http-fallback", "nf", false, "disable http fallback registration"),
 		flagSet.BoolVar(&cliOptions.Persistent, "persist", false, "enables persistent interactsh sessions"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", options.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", options.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
 	)
 
 	options.CreateGroup(flagSet, "filter", "Filter",
@@ -62,10 +64,12 @@ func main() {
 	}
 
 	client, err := client.New(&client.Options{
-		ServerURL:           cliOptions.ServerURL,
-		PersistentSession:   cliOptions.Persistent,
-		Token:               cliOptions.Token,
-		DisableHTTPFallback: cliOptions.DisableHTTPFallback,
+		ServerURL:                cliOptions.ServerURL,
+		PersistentSession:        cliOptions.Persistent,
+		Token:                    cliOptions.Token,
+		DisableHTTPFallback:      cliOptions.DisableHTTPFallback,
+		CorrelationIdLength:      cliOptions.CorrelationIdLength,
+		CorrelationIdNonceLength: cliOptions.CorrelationIdNonceLength,
 	})
 	if err != nil {
 		gologger.Fatal().Msgf("Could not create client: %s\n", err)

--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projectdiscovery/interactsh/pkg/client"
 	"github.com/projectdiscovery/interactsh/pkg/options"
 	"github.com/projectdiscovery/interactsh/pkg/server"
+	"github.com/projectdiscovery/interactsh/pkg/settings"
 )
 
 func main() {
@@ -32,8 +33,8 @@ func main() {
 		flagSet.IntVarP(&cliOptions.PollInterval, "poll-interval", "pi", 5, "poll interval in seconds to pull interaction data"),
 		flagSet.BoolVarP(&cliOptions.DisableHTTPFallback, "no-http-fallback", "nf", false, "disable http fallback registration"),
 		flagSet.BoolVar(&cliOptions.Persistent, "persist", false, "enables persistent interactsh sessions"),
-		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", options.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
-		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", options.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", settings.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", settings.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
 	)
 
 	options.CreateGroup(flagSet, "filter", "Filter",

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -36,6 +36,8 @@ func main() {
 		flagSet.StringVarP(&cliOptions.Token, "token", "t", "", "enable authentication to server using given token"),
 		flagSet.StringVar(&cliOptions.OriginURL, "acao-url", "https://app.interactsh.com", "origin url to send in acao header (required to use web-client)"),
 		flagSet.BoolVarP(&cliOptions.SkipAcme, "skip-acme", "sa", false, "skip acme registration (certificate checks/handshake + TLS protocols will be disabled)"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", options.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", options.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
 	)
 	options.CreateGroup(flagSet, "services", "Services",
 		flagSet.IntVar(&cliOptions.DnsPort, "dns-port", 53, "port to use for dns service"),

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/projectdiscovery/interactsh/pkg/options"
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/interactsh/pkg/server/acme"
+	"github.com/projectdiscovery/interactsh/pkg/settings"
 	"github.com/projectdiscovery/interactsh/pkg/storage"
 )
 
@@ -36,8 +37,8 @@ func main() {
 		flagSet.StringVarP(&cliOptions.Token, "token", "t", "", "enable authentication to server using given token"),
 		flagSet.StringVar(&cliOptions.OriginURL, "acao-url", "https://app.interactsh.com", "origin url to send in acao header (required to use web-client)"),
 		flagSet.BoolVarP(&cliOptions.SkipAcme, "skip-acme", "sa", false, "skip acme registration (certificate checks/handshake + TLS protocols will be disabled)"),
-		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", options.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
-		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", options.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", settings.CorrelationIdLengthDefault, "Length of the correlation id preamble"),
+		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", settings.CorrelationIdNonceLengthLengthDefault, "Length of the correlation id nonce"),
 	)
 	options.CreateGroup(flagSet, "services", "Services",
 		flagSet.IntVar(&cliOptions.DnsPort, "dns-port", 53, "port to use for dns service"),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,8 +23,8 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
-	"github.com/projectdiscovery/interactsh/pkg/options"
 	"github.com/projectdiscovery/interactsh/pkg/server"
+	"github.com/projectdiscovery/interactsh/pkg/settings"
 	"github.com/projectdiscovery/retryablehttp-go"
 	"github.com/rs/xid"
 	"gopkg.in/corvus-ch/zbase32.v1"
@@ -66,8 +66,8 @@ type Options struct {
 // DefaultOptions is the default options for the interact client
 var DefaultOptions = &Options{
 	ServerURL:                "oast.pro,oast.live,oast.site,oast.online,oast.fun,oast.me",
-	CorrelationIdLength:      options.CorrelationIdLengthDefault,
-	CorrelationIdNonceLength: options.CorrelationIdLengthDefault,
+	CorrelationIdLength:      settings.CorrelationIdLengthDefault,
+	CorrelationIdNonceLength: settings.CorrelationIdLengthDefault,
 }
 
 // New creates a new client instance based on provided options
@@ -396,7 +396,7 @@ func (c *Client) performRegistration(serverURL string, payload []byte) error {
 // URL returns a new URL that can be used for external interaction requests.
 func (c *Client) URL() string {
 	data := make([]byte, c.CorrelationIdNonceLength)
-	rand.Read(data)
+	_, _ = rand.Read(data)
 	randomData := zbase32.StdEncoding.EncodeToString(data)
 	if len(randomData) > c.CorrelationIdNonceLength {
 		randomData = randomData[:c.CorrelationIdNonceLength]

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -18,13 +17,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/interactsh/pkg/options"
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/retryablehttp-go"
 	"github.com/rs/xid"
@@ -33,19 +32,19 @@ import (
 
 var authError = errors.New("couldn't authenticate to the server")
 
-var objectIDCounter = uint32(0)
-
 // Client is a client for communicating with interactsh server instance.
 type Client struct {
-	correlationID       string
-	secretKey           string
-	serverURL           *url.URL
-	httpClient          *retryablehttp.Client
-	privKey             *rsa.PrivateKey
-	quitChan            chan struct{}
-	persistentSession   bool
-	disableHTTPFallback bool
-	token               string
+	correlationID            string
+	secretKey                string
+	serverURL                *url.URL
+	httpClient               *retryablehttp.Client
+	privKey                  *rsa.PrivateKey
+	quitChan                 chan struct{}
+	persistentSession        bool
+	disableHTTPFallback      bool
+	token                    string
+	correlationIdLength      int
+	CorrelationIdNonceLength int
 }
 
 // Options contains configuration options for interactsh client
@@ -58,28 +57,48 @@ type Options struct {
 	Token string
 	// DisableHTTPFallback determines if failed requests over https should not be retried over http
 	DisableHTTPFallback bool
+	// CorrelationIdLength of the preamble
+	CorrelationIdLength int
+	// CorrelationIdNonceLengthLength of the nonce
+	CorrelationIdNonceLength int
 }
 
 // DefaultOptions is the default options for the interact client
 var DefaultOptions = &Options{
-	ServerURL: "oast.pro,oast.live,oast.site,oast.online,oast.fun,oast.me",
+	ServerURL:                "oast.pro,oast.live,oast.site,oast.online,oast.fun,oast.me",
+	CorrelationIdLength:      options.CorrelationIdLengthDefault,
+	CorrelationIdNonceLength: options.CorrelationIdLengthDefault,
 }
 
 // New creates a new client instance based on provided options
 func New(options *Options) (*Client, error) {
 	mathrand.Seed(time.Now().UnixNano())
 
+	// if correlation id lengths and nonce are not specified fallback to default:
+	if options.CorrelationIdLength == 0 {
+		options.CorrelationIdLength = DefaultOptions.CorrelationIdLength
+	}
+	if options.CorrelationIdNonceLength == 0 {
+		options.CorrelationIdNonceLength = DefaultOptions.CorrelationIdNonceLength
+	}
+
 	opts := retryablehttp.DefaultOptionsSingle
 	opts.Timeout = 10 * time.Second
-
 	// Generate a random ksuid which will be used as server secret.
+	correlationID := xid.New().String()
+	if len(correlationID) > options.CorrelationIdLength {
+		correlationID = correlationID[:options.CorrelationIdLength]
+	}
+
 	client := &Client{
-		secretKey:           uuid.New().String(), // uuid as more secure
-		correlationID:       xid.New().String(),
-		persistentSession:   options.PersistentSession,
-		httpClient:          retryablehttp.NewClient(opts),
-		token:               options.Token,
-		disableHTTPFallback: options.DisableHTTPFallback,
+		secretKey:                uuid.New().String(), // uuid as more secure
+		correlationID:            correlationID,
+		persistentSession:        options.PersistentSession,
+		httpClient:               retryablehttp.NewClient(opts),
+		token:                    options.Token,
+		disableHTTPFallback:      options.DisableHTTPFallback,
+		correlationIdLength:      options.CorrelationIdLength,
+		CorrelationIdNonceLength: options.CorrelationIdNonceLength,
 	}
 	payload, err := client.initializeRSAKeys()
 	if err != nil {
@@ -150,7 +169,6 @@ func (c *Client) parseServerURLs(serverURL string, payload []byte) error {
 		if err != nil {
 			return errors.Wrap(err, "could not parse server URL")
 		}
-		parsed.Scheme = "https" // by default prefer https
 	makeReq:
 		if err := c.performRegistration(parsed.String(), payload); err != nil {
 			if !c.disableHTTPFallback && parsed.Scheme == "https" {
@@ -377,11 +395,12 @@ func (c *Client) performRegistration(serverURL string, payload []byte) error {
 
 // URL returns a new URL that can be used for external interaction requests.
 func (c *Client) URL() string {
-	random := make([]byte, 8)
-	i := atomic.AddUint32(&objectIDCounter, 1)
-	binary.BigEndian.PutUint32(random[0:4], uint32(time.Now().Unix()))
-	binary.BigEndian.PutUint32(random[4:8], i)
-	randomData := zbase32.StdEncoding.EncodeToString(random)
+	data := make([]byte, c.CorrelationIdNonceLength)
+	rand.Read(data)
+	randomData := zbase32.StdEncoding.EncodeToString(data)
+	if len(randomData) > c.CorrelationIdNonceLength {
+		randomData = randomData[:c.CorrelationIdNonceLength]
+	}
 
 	builder := &strings.Builder{}
 	builder.Grow(len(c.correlationID) + len(randomData) + len(c.serverURL.Host) + 1)

--- a/pkg/options/client_options.go
+++ b/pkg/options/client_options.go
@@ -1,16 +1,18 @@
 package options
 
 type CLIClientOptions struct {
-	ServerURL           string
-	NumberOfPayloads    int
-	Output              string
-	JSON                bool
-	Verbose             bool
-	PollInterval        int
-	Persistent          bool
-	DNSOnly             bool
-	HTTPOnly            bool
-	SmtpOnly            bool
-	Token               string
-	DisableHTTPFallback bool
+	ServerURL                string
+	NumberOfPayloads         int
+	Output                   string
+	JSON                     bool
+	Verbose                  bool
+	PollInterval             int
+	Persistent               bool
+	DNSOnly                  bool
+	HTTPOnly                 bool
+	SmtpOnly                 bool
+	Token                    string
+	DisableHTTPFallback      bool
+	CorrelationIdLength      int
+	CorrelationIdNonceLength int
 }

--- a/pkg/options/default.go
+++ b/pkg/options/default.go
@@ -1,0 +1,6 @@
+package options
+
+const (
+	CorrelationIdLengthDefault            = 20
+	CorrelationIdNonceLengthLengthDefault = 13
+)

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -3,52 +3,56 @@ package options
 import "github.com/projectdiscovery/interactsh/pkg/server"
 
 type CLIServerOptions struct {
-	Debug              bool
-	Domain             string
-	DnsPort            int
-	IPAddress          string
-	ListenIP           string
-	HttpPort           int
-	HttpsPort          int
-	Hostmaster         string
-	LdapWithFullLogger bool
-	Eviction           int
-	Responder          bool
-	Smb                bool
-	SmbPort            int
-	SmtpPort           int
-	SmtpsPort          int
-	SmtpAutoTLSPort    int
-	FtpPort            int
-	LdapPort           int
-	Ftp                bool
-	Auth               bool
-	Token              string
-	OriginURL          string
-	RootTLD            bool
-	FTPDirectory       string
-	SkipAcme           bool
+	Debug                    bool
+	Domain                   string
+	DnsPort                  int
+	IPAddress                string
+	ListenIP                 string
+	HttpPort                 int
+	HttpsPort                int
+	Hostmaster               string
+	LdapWithFullLogger       bool
+	Eviction                 int
+	Responder                bool
+	Smb                      bool
+	SmbPort                  int
+	SmtpPort                 int
+	SmtpsPort                int
+	SmtpAutoTLSPort          int
+	FtpPort                  int
+	LdapPort                 int
+	Ftp                      bool
+	Auth                     bool
+	Token                    string
+	OriginURL                string
+	RootTLD                  bool
+	FTPDirectory             string
+	SkipAcme                 bool
+	CorrelationIdLength      int
+	CorrelationIdNonceLength int
 }
 
 func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 	return &server.Options{
-		Domain:          cliServerOptions.Domain,
-		DnsPort:         cliServerOptions.DnsPort,
-		IPAddress:       cliServerOptions.IPAddress,
-		ListenIP:        cliServerOptions.ListenIP,
-		HttpPort:        cliServerOptions.HttpPort,
-		HttpsPort:       cliServerOptions.HttpsPort,
-		Hostmaster:      cliServerOptions.Hostmaster,
-		SmbPort:         cliServerOptions.SmbPort,
-		SmtpPort:        cliServerOptions.SmtpPort,
-		SmtpsPort:       cliServerOptions.SmtpsPort,
-		SmtpAutoTLSPort: cliServerOptions.SmtpAutoTLSPort,
-		FtpPort:         cliServerOptions.FtpPort,
-		LdapPort:        cliServerOptions.LdapPort,
-		Auth:            cliServerOptions.Auth,
-		Token:           cliServerOptions.Token,
-		OriginURL:       cliServerOptions.OriginURL,
-		RootTLD:         cliServerOptions.RootTLD,
-		FTPDirectory:    cliServerOptions.FTPDirectory,
+		Domain:                   cliServerOptions.Domain,
+		DnsPort:                  cliServerOptions.DnsPort,
+		IPAddress:                cliServerOptions.IPAddress,
+		ListenIP:                 cliServerOptions.ListenIP,
+		HttpPort:                 cliServerOptions.HttpPort,
+		HttpsPort:                cliServerOptions.HttpsPort,
+		Hostmaster:               cliServerOptions.Hostmaster,
+		SmbPort:                  cliServerOptions.SmbPort,
+		SmtpPort:                 cliServerOptions.SmtpPort,
+		SmtpsPort:                cliServerOptions.SmtpsPort,
+		SmtpAutoTLSPort:          cliServerOptions.SmtpAutoTLSPort,
+		FtpPort:                  cliServerOptions.FtpPort,
+		LdapPort:                 cliServerOptions.LdapPort,
+		Auth:                     cliServerOptions.Auth,
+		Token:                    cliServerOptions.Token,
+		OriginURL:                cliServerOptions.OriginURL,
+		RootTLD:                  cliServerOptions.RootTLD,
+		FTPDirectory:             cliServerOptions.FTPDirectory,
+		CorrelationIdLength:      cliServerOptions.CorrelationIdLength,
+		CorrelationIdNonceLength: cliServerOptions.CorrelationIdNonceLength,
 	}
 }

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -240,7 +240,7 @@ func (h *DNSServer) handleInteraction(domain string, w dns.ResponseWriter, r *dn
 	if strings.HasSuffix(domain, h.dotDomain) {
 		parts := strings.Split(domain, ".")
 		for i, part := range parts {
-			if len(part) == 33 {
+			if len(part) == h.options.GetIdLength() {
 				uniqueID = part
 				fullID = part
 				if i+1 <= len(parts) {
@@ -252,7 +252,7 @@ func (h *DNSServer) handleInteraction(domain string, w dns.ResponseWriter, r *dn
 	uniqueID = strings.ToLower(uniqueID)
 
 	if uniqueID != "" {
-		correlationID := uniqueID[:20]
+		correlationID := uniqueID[:h.options.CorrelationIdLength]
 		host, _, _ := net.SplitHostPort(w.RemoteAddr().String())
 		interaction := &Interaction{
 			Protocol:      "dns",

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -116,7 +116,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		var uniqueID, fullID string
 		parts := strings.Split(r.Host, ".")
 		for i, part := range parts {
-			if len(part) == 33 {
+			if len(part) == h.options.GetIdLength() {
 				uniqueID = part
 				fullID = part
 				if i+1 <= len(parts) {
@@ -125,7 +125,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 			}
 		}
 		if uniqueID != "" {
-			correlationID := uniqueID[:20]
+			correlationID := uniqueID[:h.options.CorrelationIdLength]
 
 			host, _, _ := net.SplitHostPort(r.RemoteAddr)
 			interaction := &Interaction{
@@ -162,7 +162,7 @@ You should investigate the sites where these interactions were generated from, a
 
 // defaultHandler is a handler for default collaborator requests
 func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
-	reflection := URLReflection(req.Host)
+	reflection := h.options.URLReflection(req.Host)
 	w.Header().Set("Server", h.domain)
 
 	if req.URL.Path == "/" && reflection == "" {

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -120,7 +120,7 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 		partChunks := strings.Split(part, ".")
 		if len(partChunks) > 0 {
 			for i, partChunk := range partChunks {
-				if len(partChunk) == 33 {
+				if len(partChunk) == ldapServer.options.GetIdLength() {
 					uniqueID = partChunk
 					fullID = partChunk
 					if i+1 <= len(partChunks) {
@@ -132,7 +132,7 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	}
 
 	if uniqueID != "" {
-		correlationID := uniqueID[:20]
+		correlationID := uniqueID[:ldapServer.options.CorrelationIdLength]
 		interaction := &Interaction{
 			Protocol:      "ldap",
 			UniqueID:      uniqueID,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,14 +70,22 @@ type Options struct {
 	OriginURL string
 	// FTPDirectory or temporary one
 	FTPDirectory string
+	// CorrelationIdLength of preamble
+	CorrelationIdLength int
+	// CorrelationIdNonceLength of the unique identifier
+	CorrelationIdNonceLength int
 
 	ACMEStore *acme.Provider
 }
 
+func (options *Options) GetIdLength() int {
+	return options.CorrelationIdLength + options.CorrelationIdNonceLength
+}
+
 // URLReflection returns a reversed part of the URL payload
 // which is checked in the response.
-func URLReflection(URL string) string {
-	randomID := getURLIDComponent(URL)
+func (options *Options) URLReflection(URL string) string {
+	randomID := options.getURLIDComponent(URL)
 
 	rns := []rune(randomID)
 	for i, j := 0, len(rns)-1; i < j; i, j = i+1, j-1 {
@@ -86,13 +94,13 @@ func URLReflection(URL string) string {
 	return string(rns)
 }
 
-// getURLIDComponent returns the 33 character interactsh ID
-func getURLIDComponent(URL string) string {
+// getURLIDComponent returns the interactsh ID
+func (options *Options) getURLIDComponent(URL string) string {
 	parts := strings.Split(URL, ".")
 
 	var randomID string
 	for _, part := range parts {
-		if len(part) == 33 {
+		if len(part) == options.GetIdLength() {
 			randomID = part
 		}
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,12 +3,12 @@ package server
 import (
 	"testing"
 
-	"github.com/projectdiscovery/interactsh/pkg/options"
+	"github.com/projectdiscovery/interactsh/pkg/settings"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetURLIDComponent(t *testing.T) {
-	options := Options{CorrelationIdLength: options.CorrelationIdLengthDefault, CorrelationIdNonceLength: options.CorrelationIdNonceLengthLengthDefault}
+	options := Options{CorrelationIdLength: settings.CorrelationIdLengthDefault, CorrelationIdNonceLength: settings.CorrelationIdNonceLengthLengthDefault}
 	random := options.getURLIDComponent("c6rj61aciaeutn2ae680cg5ugboyyyyyn.interactsh.com")
 	require.Equal(t, "c6rj61aciaeutn2ae680cg5ugboyyyyyn", random, "could not get correct component")
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,10 +3,12 @@ package server
 import (
 	"testing"
 
+	"github.com/projectdiscovery/interactsh/pkg/options"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetURLIDComponent(t *testing.T) {
-	random := getURLIDComponent("c6rj61aciaeutn2ae680cg5ugboyyyyyn.interactsh.com")
+	options := Options{CorrelationIdLength: options.CorrelationIdLengthDefault, CorrelationIdNonceLength: options.CorrelationIdNonceLengthLengthDefault}
+	random := options.getURLIDComponent("c6rj61aciaeutn2ae680cg5ugboyyyyyn.interactsh.com")
 	require.Equal(t, "c6rj61aciaeutn2ae680cg5ugboyyyyyn", random, "could not get correct component")
 }

--- a/pkg/server/smtp_server.go
+++ b/pkg/server/smtp_server.go
@@ -115,10 +115,10 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 	}
 
 	for _, addr := range to {
-		if len(addr) > 33 && strings.Contains(addr, "@") {
+		if len(addr) > h.options.GetIdLength() && strings.Contains(addr, "@") {
 			parts := strings.Split(addr[strings.Index(addr, "@")+1:], ".")
 			for i, part := range parts {
-				if len(part) == 33 {
+				if len(part) == h.options.GetIdLength() {
 					uniqueID = part
 					fullID = part
 					if i+1 <= len(parts) {
@@ -131,7 +131,7 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 	if uniqueID != "" {
 		host, _, _ := net.SplitHostPort(remoteAddr.String())
 
-		correlationID := uniqueID[:20]
+		correlationID := uniqueID[:h.options.CorrelationIdLength]
 		interaction := &Interaction{
 			Protocol:      "smtp",
 			UniqueID:      uniqueID,

--- a/pkg/settings/default.go
+++ b/pkg/settings/default.go
@@ -1,4 +1,4 @@
-package options
+package settings
 
 const (
 	CorrelationIdLengthDefault            = 20


### PR DESCRIPTION
## Description
This PR makes the correlation id length parametrizable through two new flags:
- `correlation-id-length`: length of the unique correlation id (default to 20)
- `correlation-id-nonce-length`: length of random data part (default to 13)