### PR TITLE
Improving token detection with textual window slider

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -36,6 +36,7 @@ func main() {
 		flagSet.StringVarP(&cliOptions.Token, "token", "t", "", "enable authentication to server using given token"),
 		flagSet.StringVar(&cliOptions.OriginURL, "acao-url", "https://app.interactsh.com", "origin url to send in acao header (required to use web-client)"),
 		flagSet.BoolVarP(&cliOptions.SkipAcme, "skip-acme", "sa", false, "skip acme registration (certificate checks/handshake + TLS protocols will be disabled)"),
+		flagSet.BoolVarP(&cliOptions.ScanEverywhere, "scan-everywhere", "se", false, "Scan canary token everywhere"),
 	)
 	options.CreateGroup(flagSet, "services", "Services",
 		flagSet.IntVar(&cliOptions.DnsPort, "dns-port", 53, "port to use for dns service"),

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a
 	github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/caddyserver/certmagic v0.15.2
 	github.com/goburrow/cache v0.1.4
 	github.com/google/uuid v1.3.0
@@ -20,7 +21,7 @@ require (
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/retryabledns v1.0.12
 	github.com/projectdiscovery/retryablehttp-go v1.0.2
-	github.com/projectdiscovery/stringsutil v0.0.0-20210823090203-2f5f137e8e1d
+	github.com/projectdiscovery/stringsutil v0.0.0-20220131190735-3d21e8f77108
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/rs/xid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/projectdiscovery/retryabledns v1.0.12/go.mod h1:4sMC8HZyF01HXukRleSQY
 github.com/projectdiscovery/retryablehttp-go v1.0.2 h1:LV1/KAQU+yeWhNVlvveaYFsjBYRwXlNEq0PvrezMV0U=
 github.com/projectdiscovery/retryablehttp-go v1.0.2/go.mod h1:dx//aY9V247qHdsRf0vdWHTBZuBQ2vm6Dq5dagxrDYI=
 github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
-github.com/projectdiscovery/stringsutil v0.0.0-20220131190735-3d21e8f77108 h1:4exEM2V0HDFB+ARZ1R9T0CJvnbaQiq39RD2wot9jfRs=
-github.com/projectdiscovery/stringsutil v0.0.0-20220131190735-3d21e8f77108/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
+github.com/projectdiscovery/stringsutil v0.0.0-20220208075244-7c05502ca8e9 h1:4fvUw6b4sS4GoWbHr60mJo3dI//4mGt3BuLx8Sz9aNw=
+github.com/projectdiscovery/stringsutil v0.0.0-20220208075244-7c05502ca8e9/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a/go.mod h1:C7hXLmF
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd h1:RTWs+wEY9efxTKK5aFic5C5KybqQelGcX+JdM69KoTo=
 github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd/go.mod h1:AqtPw7WNT0O69k+AbPKWVGYeW94TqgMW/g+Ppc8AZr4=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/caddyserver/certmagic v0.15.2 h1:OMTakTsLM1ZfzMDjwvYprfUgFzpVPh3u87oxMPwmeBc=
@@ -85,8 +87,8 @@ github.com/projectdiscovery/retryabledns v1.0.12/go.mod h1:4sMC8HZyF01HXukRleSQY
 github.com/projectdiscovery/retryablehttp-go v1.0.2 h1:LV1/KAQU+yeWhNVlvveaYFsjBYRwXlNEq0PvrezMV0U=
 github.com/projectdiscovery/retryablehttp-go v1.0.2/go.mod h1:dx//aY9V247qHdsRf0vdWHTBZuBQ2vm6Dq5dagxrDYI=
 github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
-github.com/projectdiscovery/stringsutil v0.0.0-20210823090203-2f5f137e8e1d h1:lrdpJCBOvRrTnm44Ov7O3tLd3oOWhCvVUhTKkWwibq4=
-github.com/projectdiscovery/stringsutil v0.0.0-20210823090203-2f5f137e8e1d/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
+github.com/projectdiscovery/stringsutil v0.0.0-20220131190735-3d21e8f77108 h1:4exEM2V0HDFB+ARZ1R9T0CJvnbaQiq39RD2wot9jfRs=
+github.com/projectdiscovery/stringsutil v0.0.0-20220131190735-3d21e8f77108/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -28,6 +28,7 @@ type CLIServerOptions struct {
 	RootTLD            bool
 	FTPDirectory       string
 	SkipAcme           bool
+	ScanEverywhere     bool
 }
 
 func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
@@ -50,5 +51,6 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		OriginURL:       cliServerOptions.OriginURL,
 		RootTLD:         cliServerOptions.RootTLD,
 		FTPDirectory:    cliServerOptions.FTPDirectory,
+		ScanEverywhere:  cliServerOptions.ScanEverywhere,
 	}
 }

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -240,7 +240,7 @@ func (h *DNSServer) handleInteraction(domain string, w dns.ResponseWriter, r *dn
 	if strings.HasSuffix(domain, h.dotDomain) {
 		parts := strings.Split(domain, ".")
 		for i, part := range parts {
-			if len(part) == 33 {
+			if isCorrelationID(part) {
 				uniqueID = part
 				fullID = part
 				if i+1 <= len(parts) {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -115,9 +115,12 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		}
 
 		if h.options.ScanEverywhere {
-			for part := range stringsutil.SlideWithLength(reqString, 33) {
-				if isCorrelationID(part) {
-					h.handleInteraction(part, part, reqString, respString, r.RemoteAddr)
+			chunks := stringsutil.SplitAny(reqString, ".\n\t\"'")
+			for _, chunk := range chunks {
+				for part := range stringsutil.SlideWithLength(chunk, 33) {
+					if isCorrelationID(part) {
+						h.handleInteraction(part, part, reqString, respString, r.RemoteAddr)
+					}
 				}
 			}
 		} else {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -14,6 +14,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/stringsutil"
 )
 
 // HTTPServer is a http server instance that listens both
@@ -79,7 +80,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		handler.ServeHTTP(rec, r)
 
 		resp, _ := httputil.DumpResponse(rec.Result(), true)
-		resoString := string(resp)
+		respString := string(resp)
 
 		for k, v := range rec.Header() {
 			w.Header()[k] = v
@@ -98,7 +99,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 				UniqueID:      r.Host,
 				FullId:        r.Host,
 				RawRequest:    reqString,
-				RawResponse:   resoString,
+				RawResponse:   respString,
 				RemoteAddress: host,
 				Timestamp:     time.Now(),
 			}
@@ -113,40 +114,48 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 			}
 		}
 
-		var uniqueID, fullID string
-		parts := strings.Split(r.Host, ".")
-		for i, part := range parts {
-			if len(part) == 33 {
-				uniqueID = part
-				fullID = part
-				if i+1 <= len(parts) {
-					fullID = strings.Join(parts[:i+1], ".")
+		if h.options.ScanEverywhere {
+			for part := range stringsutil.SlideWithLength(reqString, 33) {
+				if isCorrelationID(part) {
+					h.handleInteraction(part, part, reqString, respString, r.RemoteAddr)
+				}
+			}
+		} else {
+			parts := strings.Split(r.Host, ".")
+			for i, part := range parts {
+				if isCorrelationID(part) {
+					fullID := part
+					if i+1 <= len(parts) {
+						fullID = strings.Join(parts[:i+1], ".")
+					}
+					h.handleInteraction(part, fullID, reqString, respString, r.RemoteAddr)
 				}
 			}
 		}
-		if uniqueID != "" {
-			correlationID := uniqueID[:20]
+	}
+}
 
-			host, _, _ := net.SplitHostPort(r.RemoteAddr)
-			interaction := &Interaction{
-				Protocol:      "http",
-				UniqueID:      uniqueID,
-				FullId:        fullID,
-				RawRequest:    reqString,
-				RawResponse:   resoString,
-				RemoteAddress: host,
-				Timestamp:     time.Now(),
-			}
-			buffer := &bytes.Buffer{}
-			if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
-				gologger.Warning().Msgf("Could not encode http interaction: %s\n", err)
-			} else {
-				gologger.Debug().Msgf("HTTP Interaction: \n%s\n", buffer.String())
+func (h *HTTPServer) handleInteraction(uniqueID, fullID, reqString, respString, hostPort string) {
+	correlationID := uniqueID[:20]
 
-				if err := h.options.Storage.AddInteraction(correlationID, buffer.Bytes()); err != nil {
-					gologger.Warning().Msgf("Could not store http interaction: %s\n", err)
-				}
-			}
+	host, _, _ := net.SplitHostPort(hostPort)
+	interaction := &Interaction{
+		Protocol:      "http",
+		UniqueID:      uniqueID,
+		FullId:        fullID,
+		RawRequest:    reqString,
+		RawResponse:   respString,
+		RemoteAddress: host,
+		Timestamp:     time.Now(),
+	}
+	buffer := &bytes.Buffer{}
+	if err := jsoniter.NewEncoder(buffer).Encode(interaction); err != nil {
+		gologger.Warning().Msgf("Could not encode http interaction: %s\n", err)
+	} else {
+		gologger.Debug().Msgf("HTTP Interaction: \n%s\n", buffer.String())
+
+		if err := h.options.Storage.AddInteraction(correlationID, buffer.Bytes()); err != nil {
+			gologger.Warning().Msgf("Could not store http interaction: %s\n", err)
 		}
 	}
 }

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -10,6 +10,7 @@ import (
 	ldap "github.com/Mzack9999/ldapserver"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/stringsutil"
 )
 
 // Most routes handlers are taken from the example at https://github.com/vjeantet/ldapserver/blob/master/examples/complex/main.go
@@ -115,29 +116,37 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	res := ldap.NewSearchResultDoneResponse(ldap.LDAPResultSuccess)
 	w.Write(res)
 
-	parts := ldapServer.splitSearchMsg(string(baseObject))
-	for _, part := range parts {
+	for _, part := range stringsutil.SplitAny(string(baseObject), "=,") {
 		partChunks := strings.Split(part, ".")
-		if len(partChunks) > 0 {
-			for i, partChunk := range partChunks {
-				if len(partChunk) == 33 {
+		for i, partChunk := range partChunks {
+			if ldapServer.options.ScanEverywhere {
+				for scanChunk := range stringsutil.SlideWithLength(partChunk, 33) {
+					if isCorrelationID(scanChunk) {
+						ldapServer.handleInteraction(scanChunk, scanChunk, message.String(), host)
+					}
+				}
+			} else {
+				if isCorrelationID(partChunk) {
 					uniqueID = partChunk
 					fullID = partChunk
 					if i+1 <= len(partChunks) {
 						fullID = strings.Join(partChunks[:i+1], ".")
 					}
+					ldapServer.handleInteraction(uniqueID, fullID, message.String(), host)
 				}
 			}
 		}
 	}
+}
 
+func (ldapServer *LDAPServer) handleInteraction(uniqueID, fullID, reqString, host string) {
 	if uniqueID != "" {
 		correlationID := uniqueID[:20]
 		interaction := &Interaction{
 			Protocol:      "ldap",
 			UniqueID:      uniqueID,
 			FullId:        fullID,
-			RawRequest:    message.String(),
+			RawRequest:    reqString,
 			RemoteAddress: host,
 			Timestamp:     time.Now(),
 		}
@@ -157,17 +166,9 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	if ldapServer.WithLogger {
 		ldapServer.logInteraction(Interaction{
 			RemoteAddress: host,
-			RawRequest:    message.String(),
+			RawRequest:    reqString,
 		})
 	}
-}
-
-func (LDAPServer *LDAPServer) splitSearchMsg(data string) (parts []string) {
-	tokens := strings.Split(data, ",")
-	for _, token := range tokens {
-		parts = append(parts, strings.Split(token, "=")...)
-	}
-	return parts
 }
 
 // handleAbandon is a handler for abandon requests

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,6 +70,8 @@ type Options struct {
 	OriginURL string
 	// FTPDirectory or temporary one
 	FTPDirectory string
+	// ScanEverywhere for potential correlation id
+	ScanEverywhere bool
 
 	ACMEStore *acme.Provider
 }
@@ -92,7 +94,7 @@ func getURLIDComponent(URL string) string {
 
 	var randomID string
 	for _, part := range parts {
-		if len(part) == 33 {
+		if isCorrelationID(part) {
 			randomID = part
 		}
 	}

--- a/pkg/server/smtp_server.go
+++ b/pkg/server/smtp_server.go
@@ -118,7 +118,7 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 		if len(addr) > 33 && strings.Contains(addr, "@") {
 			parts := strings.Split(addr[strings.Index(addr, "@")+1:], ".")
 			for i, part := range parts {
-				if len(part) == 33 {
+				if isCorrelationID(part) {
 					uniqueID = part
 					fullID = part
 					if i+1 <= len(parts) {

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -2,8 +2,14 @@ package server
 
 import (
 	"github.com/asaskevich/govalidator"
+	"github.com/rs/xid"
 )
 
 func isCorrelationID(s string) bool {
-	return len(s) == 33 && govalidator.IsAlphanumeric(s)
+	if len(s) == 33 && govalidator.IsAlphanumeric(s) {
+		if _, err := xid.FromString(s[:20]); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -1,0 +1,9 @@
+package server
+
+import (
+	"github.com/asaskevich/govalidator"
+)
+
+func isCorrelationID(s string) bool {
+	return len(s) == 33 && govalidator.IsAlphanumeric(s)
+}

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -5,9 +5,9 @@ import (
 	"github.com/rs/xid"
 )
 
-func isCorrelationID(s string) bool {
-	if len(s) == 33 && govalidator.IsAlphanumeric(s) {
-		if _, err := xid.FromString(s[:20]); err == nil {
+func (options *Options) isCorrelationID(s string) bool {
+	if len(s) == options.GetIdLength() && govalidator.IsAlphanumeric(s) {
+		if _, err := xid.FromString(s[:options.CorrelationIdLength]); err == nil {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description
This PR adds the flag `scan-everywhere` that enables textual research of the token across the raw request for HTTP/LDAP.

## Notes
research is performed using a forward sliding window on text chunks of `[a-z0-9]` and matching the canary length. Although this reduces false positives, some random sequences are interpreted as valid canaries anyway those will be correctly discarded as there is no registered client associated.

## How to reproduce
`interactsh-server`
```console
$ sudo go run . -listen-ip 192.168.1.16 -scan-everywhere -debug

    _       __                       __       __
   (_)___  / /____  _________ ______/ /______/ /_
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ v1.0.2-dev

		projectdiscovery.io

[INF] Listening with the following services:
[DNS] Listening on TCP 192.168.1.16:53
[SMTP] Listening on TCP 192.168.1.16:25
[HTTP] Listening on TCP 192.168.1.16:80
[DNS] Listening on UDP 192.168.1.16:53
[LDAP] Listening on TCP 192.168.1.16:389
```
`interactsh-client`
```console
$ go run . -server http://192.168.1.16 -v

    _       __                       __       __
   (_)___  / /____  _________ ______/ /______/ /_
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ v1.0.2-dev

		projectdiscovery.io

[INF] Listing 1 payload for OOB Testing
[INF] c7seq8isahsi61qv2r70c8hq4eoyyyyyn.192.168.1.16
[c7seq8isahsi61qv2r70c8hq4eoyyyyyn] Received HTTP interaction from 192.168.1.16 at 2022-02-01 09:20:11
------------
HTTP Request
------------

GET / HTTP/1.1
Host: aaa
Accept: */*
Test: aaac7seq8isahsi61qv2r70c8hq4eoyyyyyn.192.168.1.16bbb
User-Agent: curl/7.77.0



-------------
HTTP Response
-------------

HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=utf-8
Server:
...

```
`curl` (observe that the token is within a `Test` header and wrapped between random prefix/suffix)
```console
curl http://192.168.1.16 -H "Host: aaa" -H "Test: aaac7seq8isahsi61qv2r70c8hq4eoyyyyyn.192.168.1.16bbb"
```