### PR TITLE
Adding sliding support to http/ldap

### DIFF
--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -119,15 +119,9 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	for _, part := range stringsutil.SplitAny(string(baseObject), "=,") {
 		partChunks := strings.Split(part, ".")
 		for i, partChunk := range partChunks {
-			if ldapServer.options.ScanEverywhere {
-				for scanChunk := range stringsutil.SlideWithLength(partChunk, ldapServer.options.CorrelationIdLength) {
-					if ldapServer.options.isCorrelationID(scanChunk) {
-						ldapServer.handleInteraction(scanChunk, scanChunk, message.String(), host)
-					}
-				}
-			} else {
-				if ldapServer.options.isCorrelationID(partChunk) {
-					uniqueID = partChunk
+			for scanChunk := range stringsutil.SlideWithLength(partChunk, ldapServer.options.GetIdLength()) {
+				if ldapServer.options.isCorrelationID(scanChunk) {
+					uniqueID = scanChunk
 					fullID = partChunk
 					if i+1 <= len(partChunks) {
 						fullID = strings.Join(partChunks[:i+1], ".")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectdiscovery/interactsh/pkg/server/acme"
 	"github.com/projectdiscovery/interactsh/pkg/storage"
+	"github.com/projectdiscovery/stringsutil"
 )
 
 // Interaction is an interaction received to the server.
@@ -106,9 +107,12 @@ func (options *Options) getURLIDComponent(URL string) string {
 
 	var randomID string
 	for _, part := range parts {
-		if options.isCorrelationID(part) {
-			randomID = part
+		for scanChunk := range stringsutil.SlideWithLength(part, options.GetIdLength()) {
+			if options.isCorrelationID(scanChunk) {
+				randomID = part
+			}
 		}
 	}
+
 	return randomID
 }


### PR DESCRIPTION
This PR adds sliding support for HTTP/LDAP protocols, allowing a correlation-id to be matched with arbitrary prefixes