### PR TITLE
Fixing short-id detection logic

### DIFF
--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -7,7 +7,10 @@ import (
 
 func (options *Options) isCorrelationID(s string) bool {
 	if len(s) == options.GetIdLength() && govalidator.IsAlphanumeric(s) {
-		if _, err := xid.FromString(s[:options.CorrelationIdLength]); err == nil {
+		// xid should be 12
+		if options.CorrelationIdLength != 12 {
+			return true
+		} else if _, err := xid.FromString(s[:options.CorrelationIdLength]); err == nil {
 			return true
 		}
 	}


### PR DESCRIPTION
This PR implements a fix for short/long correlation id, as they were erroneously parsed as 12 bytes `xid`