### PR TITLE
Adding support for TLS certificate nested subdomain

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -138,14 +138,11 @@ func main() {
 	var tlsConfig *tls.Config
 	switch {
 	case cliOptions.CertificatePath != "" && cliOptions.PrivateKeyPath != "":
-		cert, err := tls.LoadX509KeyPair(cliOptions.CertificatePath, cliOptions.PrivateKeyPath)
-		if err != nil {
-			gologger.Error().Msgf("Could not load certs and private key for auto TLS, https will be disabled")
-		}
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true,
-			Certificates:       []tls.Certificate{cert},
-			ServerName:         cliOptions.Domain,
+		acmeManagerTLS, acmeErr := acme.BuildTlsConfigWithCertAndKeyPaths(cliOptions.CertificatePath, cliOptions.PrivateKeyPath, cliOptions.Domain)
+		if acmeErr != nil {
+			gologger.Error().Msgf("https will be disabled: %s", acmeErr)
+		} else {
+			tlsConfig = acmeManagerTLS
 		}
 	case !cliOptions.SkipAcme && cliOptions.Domain != "":
 		acmeManagerTLS, acmeErr := acme.HandleWildcardCertificates(fmt.Sprintf("*.%s", trimmedDomain), serverOptions.Hostmaster, acmeStore, cliOptions.Debug)

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -3,11 +3,11 @@ package filewatcher
 import (
 	"bufio"
 	"errors"
-	"log"
 	"os"
 	"time"
 
 	"github.com/projectdiscovery/fileutil"
+	"github.com/projectdiscovery/gologger"
 )
 
 type Options struct {
@@ -36,7 +36,7 @@ func (f *FileWatcher) Watch() (chan string, error) {
 		for range f.watcher.C {
 			r, err := os.Open(f.Options.File)
 			if err != nil {
-				log.Fatal(err)
+				gologger.Fatal().Msgf("Couldn't monitor file: %s", err)
 				return
 			}
 			sc := bufio.NewScanner(r)

--- a/pkg/server/acme/acme_certbot.go
+++ b/pkg/server/acme/acme_certbot.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/caddyserver/certmagic"
+	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"go.uber.org/zap"
 )
@@ -56,22 +57,34 @@ func HandleWildcardCertificates(domain, email string, store *Provider, debug boo
 	if syncerr := cfg.ObtainCertSync(context.Background(), domain); syncerr != nil {
 		return nil, syncerr
 	}
+	domains := []string{domain, originalDomain}
 	go func() {
-		syncerr := cfg.ManageAsync(context.Background(), []string{domain, originalDomain})
+		syncerr := cfg.ManageAsync(context.Background(), domains)
 		if syncerr != nil {
 			gologger.Error().Msgf("Could not manageasync certmagic certs: %s", err)
 		}
 	}()
 
-	config := cfg.TLSConfig()
-	config.ServerName = originalDomain
-	config.NextProtos = []string{"h2", "http/1.1"}
-
 	if creating {
 		home, _ := os.UserHomeDir()
 		gologger.Info().Msgf("Successfully Created SSL Certificate at: %s", filepath.Join(filepath.Join(home, ".local", "share"), "certmagic"))
 	}
-	return config, nil
+
+	// attempts to extract certificates from caddy
+	var certs []tls.Certificate
+	for _, domain := range domains {
+		certPath, privKeyPath, err := extractCaddyPaths(cfg, &certmagic.DefaultACME, domain)
+		if err != nil {
+			return nil, err
+		}
+		cert, err := tls.LoadX509KeyPair(certPath, privKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+
+	return BuildTlsConfigWithCerts(domain, certs...)
 }
 
 // certAlreadyExists returns true if a cert already exists
@@ -83,4 +96,43 @@ func certAlreadyExists(cfg *certmagic.Config, issuer certmagic.Issuer, domain st
 	return cfg.Storage.Exists(certKey) &&
 		cfg.Storage.Exists(keyKey) &&
 		cfg.Storage.Exists(metaKey)
+}
+
+// extractCaddyPaths attempts to extract cert and private key through the layers of abstractions from the domain name
+func extractCaddyPaths(cfg *certmagic.Config, issuer certmagic.Issuer, domain string) (certPath, privKeyPath string, err error) {
+	issuerKey := issuer.IssuerKey()
+	certId := certmagic.StorageKeys.SiteCert(issuerKey, domain)
+	keyId := certmagic.StorageKeys.SitePrivateKey(issuerKey, domain)
+	// we need to coerce the storage to file system one to be able to obtain access to the typed methods
+	if cfgStorage, ok := cfg.Storage.(*certmagic.FileStorage); ok {
+		certPath = cfgStorage.Filename(certId)
+		privKeyPath = cfgStorage.Filename(keyId)
+	}
+	if certPath != "" && privKeyPath != "" {
+		return
+	}
+	err = errors.New("couldn't extract cert and private key paths")
+	return
+}
+
+// BuildTlsConfig with certificates
+func BuildTlsConfigWithCertAndKeyPaths(certPath, privKeyPath, domain string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, privKeyPath)
+	if err != nil {
+		return nil, errors.New("Could not load certs and private key")
+	}
+	return BuildTlsConfigWithCerts(domain, cert)
+}
+
+// BuildTlsConfigWithExistingConfig with existing certificates
+func BuildTlsConfigWithCerts(domain string, certs ...tls.Certificate) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       certs,
+	}
+	if domain != "" {
+		tlsConfig.ServerName = domain
+	}
+	tlsConfig.NextProtos = []string{"h2", "http/1.1"}
+	return tlsConfig, nil
 }


### PR DESCRIPTION
## Description
This PR adds nested subdomain handling by replacing caddy tlsconfig generation, strictly tied to the domains name list, with a custom generated one.