### PR TITLE
Adding session resume support

### DIFF
--- a/cmd/benchmark-server/bench.go
+++ b/cmd/benchmark-server/bench.go
@@ -52,9 +52,8 @@ func process() error {
 
 func benchmarkServer() {
 	client, err := client.New(&client.Options{
-		ServerURL:         *serverURL,
-		PersistentSession: false,
-		Token:             *token,
+		ServerURL: *serverURL,
+		Token:     *token,
 	})
 	if err != nil {
 		errors++

--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -40,7 +40,6 @@ func main() {
 		flagSet.StringVarP(&cliOptions.Token, "token", "t", "", "authentication token to connect protected interactsh server"),
 		flagSet.IntVarP(&cliOptions.PollInterval, "poll-interval", "pi", 5, "poll interval in seconds to pull interaction data"),
 		flagSet.BoolVarP(&cliOptions.DisableHTTPFallback, "no-http-fallback", "nf", false, "disable http fallback registration"),
-		flagSet.BoolVar(&cliOptions.Persistent, "persist", false, "enables persistent interactsh sessions"),
 		flagSet.IntVarP(&cliOptions.CorrelationIdLength, "correlation-id-length", "cidl", settings.CorrelationIdLengthDefault, "length of the correlation id preamble"),
 		flagSet.IntVarP(&cliOptions.CorrelationIdNonceLength, "correlation-id-nonce-length", "cidn", settings.CorrelationIdNonceLengthDefault, "length of the correlation id nonce"),
 		flagSet.StringVarP(&cliOptions.SessionFile, "session-file", "sf", "", "Save to/Load from session file"),
@@ -93,7 +92,6 @@ func main() {
 
 	client, err := client.New(&client.Options{
 		ServerURL:                cliOptions.ServerURL,
-		PersistentSession:        cliOptions.Persistent,
 		Token:                    cliOptions.Token,
 		DisableHTTPFallback:      cliOptions.DisableHTTPFallback,
 		CorrelationIdLength:      cliOptions.CorrelationIdLength,

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -34,11 +34,11 @@ func main() {
 	flagSet := goflags.NewFlagSet()
 	flagSet.SetDescription(`Interactsh server - Go client to configure and host interactsh server.`)
 
-	options.CreateGroup(flagSet, "config", "config",
+	flagSet.CreateGroup("config", "config",
 		flagSet.StringVar(&cliOptions.Config, "config", defaultConfigLocation, "flag configuration file"),
 	)
 
-	options.CreateGroup(flagSet, "input", "Input",
+	flagSet.CreateGroup("input", "Input",
 		flagSet.StringVarP(&cliOptions.Domain, "domain", "d", "", "configured domain to use with interactsh server"),
 		flagSet.StringVar(&cliOptions.IPAddress, "ip", "", "public ip address to use for interactsh server"),
 		flagSet.StringVarP(&cliOptions.ListenIP, "listen-ip", "lip", "0.0.0.0", "public ip address to listen on"),
@@ -53,7 +53,7 @@ func main() {
 		flagSet.StringVar(&cliOptions.CertificatePath, "cert", "", "custom certificate path"),
 		flagSet.StringVar(&cliOptions.PrivateKeyPath, "privkey", "", "custom private key path"),
 	)
-	options.CreateGroup(flagSet, "services", "Services",
+	flagSet.CreateGroup("services", "Services",
 		flagSet.IntVar(&cliOptions.DnsPort, "dns-port", 53, "port to use for dns service"),
 		flagSet.IntVar(&cliOptions.HttpPort, "http-port", 80, "port to use for http service"),
 		flagSet.IntVar(&cliOptions.HttpsPort, "https-port", 443, "port to use for https service"),
@@ -70,7 +70,7 @@ func main() {
 		flagSet.IntVar(&cliOptions.FtpPort, "ftp-port", 21, "port to use for ftp service"),
 		flagSet.StringVar(&cliOptions.FTPDirectory, "ftp-dir", "", "ftp directory - temporary if not specified"),
 	)
-	options.CreateGroup(flagSet, "debug", "Debug",
+	flagSet.CreateGroup("debug", "Debug",
 		flagSet.BoolVar(&cliOptions.Version, "version", false, "show version of the project"),
 		flagSet.BoolVar(&cliOptions.Debug, "debug", false, "start interactsh server in debug mode"),
 	)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc
 	github.com/projectdiscovery/folderutil v0.0.0-20220215113126-add60a1e8e08
-	github.com/projectdiscovery/goflags v0.0.7
+	github.com/projectdiscovery/goflags v0.0.8-0.20220412061559-5119d6086323
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/retryabledns v1.0.13
 	github.com/projectdiscovery/retryablehttp-go v1.0.2
@@ -30,4 +30,5 @@ require (
 	go.uber.org/zap v1.21.0
 	goftp.io/server/v2 v2.0.0
 	gopkg.in/corvus-ch/zbase32.v1 v1.0.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -88,12 +88,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e h1:7bwaFH1jvtOo5ndhTQgoA349ozhX+1dc4b6tbaPnBOA=
 github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e/go.mod h1:/IsapnEYiWG+yEDPXp0e8NWj3npzB9Ccy9lXEUJwMZs=
 github.com/projectdiscovery/fileutil v0.0.0-20210926202739-6050d0acf73c/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
+github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc h1:dbDgsj26PW06L3zMo7AT08IbEqMd2u8QQ1BvlfMAY2w=
 github.com/projectdiscovery/fileutil v0.0.0-20220215113056-ba188a0c8abc/go.mod h1:Pm0f+MWgDFMSSI9NBedNh48LyYPs8gD3Jd8DXGmp4aQ=
 github.com/projectdiscovery/folderutil v0.0.0-20220215113126-add60a1e8e08 h1:m1pgJisawU7zP9lKGktOEk6KNrNAR7e4Q07Kt3ox0NM=
 github.com/projectdiscovery/folderutil v0.0.0-20220215113126-add60a1e8e08/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
-github.com/projectdiscovery/goflags v0.0.7 h1:aykmRkrOgDyRwcvGrK3qp+9aqcjGfAMs/+LtRmtyxwk=
-github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=
+github.com/projectdiscovery/goflags v0.0.8-0.20220412061559-5119d6086323 h1:M9DJMe3zMnvHkt5McU1IpoTQbBYc2aB1nsOBLqWlQOs=
+github.com/projectdiscovery/goflags v0.0.8-0.20220412061559-5119d6086323/go.mod h1:uN+pHMLsWQoiZHUg/l0tqf/VdbX3+ecKfYz/H7b/+NA=
 github.com/projectdiscovery/gologger v1.0.1/go.mod h1:Ok+axMqK53bWNwDSU1nTNwITLYMXMdZtRc8/y1c7sWE=
 github.com/projectdiscovery/gologger v1.1.4 h1:qWxGUq7ukHWT849uGPkagPKF3yBPYAsTtMKunQ8O2VI=
 github.com/projectdiscovery/gologger v1.1.4/go.mod h1:Bhb6Bdx2PV1nMaFLoXNBmHIU85iROS9y1tBuv7T5pMY=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -287,7 +287,7 @@ func (c *Client) getInteractions(callback InteractionCallback) error {
 	resp, err := c.httpClient.Do(req)
 	defer func() {
 		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			_, _ = io.Copy(ioutil.Discard, resp.Body)
 		}
 	}()
@@ -374,7 +374,7 @@ func (c *Client) Close() error {
 		resp, err := c.httpClient.Do(req)
 		defer func() {
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				_, _ = io.Copy(ioutil.Discard, resp.Body)
 			}
 		}()
@@ -406,7 +406,7 @@ func (c *Client) performRegistration(serverURL string, payload []byte) error {
 	resp, err := c.httpClient.Do(req)
 	defer func() {
 		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			_, _ = io.Copy(ioutil.Discard, resp.Body)
 		}
 	}()

--- a/pkg/options/client_options.go
+++ b/pkg/options/client_options.go
@@ -17,4 +17,5 @@ type CLIClientOptions struct {
 	DisableHTTPFallback      bool
 	CorrelationIdLength      int
 	CorrelationIdNonceLength int
+	SessionFile              string
 }

--- a/pkg/options/client_options.go
+++ b/pkg/options/client_options.go
@@ -9,7 +9,6 @@ type CLIClientOptions struct {
 	JSON                     bool
 	Verbose                  bool
 	PollInterval             int
-	Persistent               bool
 	DNSOnly                  bool
 	HTTPOnly                 bool
 	SmtpOnly                 bool

--- a/pkg/options/session-info.go
+++ b/pkg/options/session-info.go
@@ -1,0 +1,9 @@
+package options
+
+type SessionInfo struct {
+	ServerURL     string `yaml:"server-url"`
+	Token         string `yaml:"server-token"`
+	PrivateKey    string `yaml:"private-key"`
+	CorrelationID string `yaml:"correlation-id"`
+	SecretKey     string `yaml:"secret-key"`
+}

--- a/pkg/options/utils.go
+++ b/pkg/options/utils.go
@@ -3,7 +3,6 @@ package options
 import (
 	"fmt"
 
-	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
 )
 
@@ -16,13 +15,6 @@ var banner = fmt.Sprintf(`
  / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
 /_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ %s
 `, Version)
-
-func CreateGroup(flagSet *goflags.FlagSet, groupName, description string, flags ...*goflags.FlagData) {
-	flagSet.SetGroup(groupName, description)
-	for _, currentFlag := range flags {
-		currentFlag.Group(groupName)
-	}
-}
 
 func ShowBanner() {
 	gologger.Print().Msgf("%s\n", banner)


### PR DESCRIPTION
## Description
This PR adds support for session resume from file through a new `-sf` flag used to specify the session file

Example:
```console
$ interactsh-client -sf resume.yaml        

    _       __                       __       __
   (_)___  / /____  _________ ______/ /______/ /_
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ 1.0.2

                projectdiscovery.io

[INF] Listing 1 payload for OOB Testing
[INF] c9c1mpg33t22pp16bae0wfc7xaaq1bx5o.oast.live
exit status 1
```