### PR TITLE
Cleanup default storage from stale OCSP entries

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -176,6 +176,9 @@ func main() {
 		}
 	}
 
+	// manually cleans up stale OCSP from storage
+	acme.CleanupStorage()
+
 	httpServer, err := server.NewHTTPServer(serverOptions)
 	if err != nil {
 		gologger.Fatal().Msgf("Could not create HTTP server")

--- a/pkg/server/acme/acme_certbot.go
+++ b/pkg/server/acme/acme_certbot.go
@@ -13,6 +13,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// CleanupStorage perform cleanup routines tasks
+func CleanupStorage() {
+	cleanupOptions := certmagic.CleanStorageOptions{OCSPStaples: true}
+	certmagic.CleanStorage(context.Background(), certmagic.Default.Storage, cleanupOptions)
+}
+
 // HandleWildcardCertificates handles ACME wildcard cert generation with DNS
 // challenge using certmagic library from caddyserver.
 func HandleWildcardCertificates(domain, email string, store *Provider, debug bool) (*tls.Config, error) {


### PR DESCRIPTION
## Description
This PR adds a manual cleanup step to remove stale/expired OCSP entries. It should prevent them from appearing within the regular internal cleanup routines.