### PR TITLE
Added customizable index pages support

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -227,7 +227,7 @@ func main() {
 
 	httpServer, err := server.NewHTTPServer(serverOptions)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create HTTP server")
+		gologger.Fatal().Msgf("Could not create HTTP server: %s", err)
 	}
 	httpAlive := make(chan bool)
 	httpsAlive := make(chan bool)
@@ -235,7 +235,7 @@ func main() {
 
 	smtpServer, err := server.NewSMTPServer(serverOptions)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create SMTP server")
+		gologger.Fatal().Msgf("Could not create SMTP server: %s", err)
 	}
 	smtpAlive := make(chan bool)
 	smtpsAlive := make(chan bool)
@@ -244,7 +244,7 @@ func main() {
 	ldapAlive := make(chan bool)
 	ldapServer, err := server.NewLDAPServer(serverOptions, cliOptions.LdapWithFullLogger)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create LDAP server")
+		gologger.Fatal().Msgf("Could not create LDAP server: %s", err)
 	}
 	go ldapServer.ListenAndServe(tlsConfig, ldapAlive)
 	defer ldapServer.Close()
@@ -253,7 +253,7 @@ func main() {
 	if cliOptions.Ftp {
 		ftpServer, err := server.NewFTPServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create FTP server")
+			gologger.Fatal().Msgf("Could not create FTP server: %s", err)
 		}
 		go ftpServer.ListenAndServe(tlsConfig, ftpAlive) //nolint
 	}
@@ -262,7 +262,7 @@ func main() {
 	if cliOptions.Responder {
 		responderServer, err := server.NewResponderServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create SMB server")
+			gologger.Fatal().Msgf("Could not create SMB server: %s", err)
 		}
 		go responderServer.ListenAndServe(responderAlive) //nolint
 		defer responderServer.Close()
@@ -272,7 +272,7 @@ func main() {
 	if cliOptions.Smb {
 		smbServer, err := server.NewSMBServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create SMB server")
+			gologger.Fatal().Msgf("Could not create SMB server: %s", err)
 		}
 		go smbServer.ListenAndServe(smbAlive) //nolint
 		defer smbServer.Close()

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -37,6 +37,8 @@ func main() {
 
 	flagSet.CreateGroup("config", "config",
 		flagSet.StringVar(&cliOptions.Config, "config", defaultConfigLocation, "flag configuration file"),
+		flagSet.StringVarP(&cliOptions.HTTPIndex, "http-index", "hi", "", "custom index file for http server"),
+		flagSet.StringVarP(&cliOptions.HTTPDirectory, "http-directory", "hd", "", "directory with files to serve with http server"),
 	)
 
 	flagSet.CreateGroup("input", "Input",

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -63,6 +63,8 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		OriginURL:                cliServerOptions.OriginURL,
 		RootTLD:                  cliServerOptions.RootTLD,
 		FTPDirectory:             cliServerOptions.FTPDirectory,
+		HTTPIndex:                cliServerOptions.HTTPIndex,
+		HTTPDirectory:            cliServerOptions.HTTPDirectory,
 		CorrelationIdLength:      cliServerOptions.CorrelationIdLength,
 		CorrelationIdNonceLength: cliServerOptions.CorrelationIdNonceLength,
 		ScanEverywhere:           cliServerOptions.ScanEverywhere,

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -28,6 +28,8 @@ type CLIServerOptions struct {
 	LdapPort                 int
 	Ftp                      bool
 	Auth                     bool
+	HTTPIndex                string
+	HTTPDirectory            string
 	Token                    string
 	OriginURL                string
 	RootTLD                  bool

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -256,7 +256,7 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	} else if stringsutil.HasSuffixI(req.URL.Path, ".xml") {
 		fmt.Fprintf(w, "<data>%s</data>", reflection)
 		w.Header().Set("Content-Type", "application/xml")
-	} else if reflection != "" {
+	} else if reflection != "" && filename == "" {
 		fmt.Fprintf(w, "<html><head></head><body>%s</body></html>", reflection)
 	} else {
 		http.ServeContent(w, req, filename, time.Now(), strings.NewReader(content))

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -244,6 +244,7 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	filename := strings.TrimPrefix(req.URL.Path, "/")
 	content, ok := h.contents[filename]
 	if !ok {
+		filename = "index.html"
 		content = h.contents["index.html"]
 	}
 

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -208,6 +208,11 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Server", domain)
 
 	if req.URL.Path == "/" && reflection == "" {
+		if h.options.HTTPIndex != "" {
+			http.ServeFile(w, req, h.options.HTTPIndex)
+		} else if h.options.HTTPDirectory != "" {
+			http.ServeFile(w, req, h.options.HTTPDirectory)
+		}
 		fmt.Fprintf(w, banner, domain)
 	} else if strings.EqualFold(req.URL.Path, "/robots.txt") {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: / # %s", reflection)

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -241,14 +241,12 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Server", domain)
 
-	content, ok := h.contents[req.URL.Path]
+	content, ok := h.contents[strings.TrimPrefix(req.URL.Path, "/")]
 	if !ok {
 		content = h.contents["index.html"]
 	}
 
-	if req.URL.Path == "/" || content != "" {
-		fmt.Fprint(w, content)
-	} else if strings.EqualFold(req.URL.Path, "/robots.txt") {
+	if strings.EqualFold(req.URL.Path, "/robots.txt") {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: / # %s", reflection)
 	} else if stringsutil.HasSuffixI(req.URL.Path, ".json") {
 		fmt.Fprintf(w, "{\"data\":\"%s\"}", reflection)
@@ -256,8 +254,10 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	} else if stringsutil.HasSuffixI(req.URL.Path, ".xml") {
 		fmt.Fprintf(w, "<data>%s</data>", reflection)
 		w.Header().Set("Content-Type", "application/xml")
-	} else {
+	} else if reflection != "" {
 		fmt.Fprintf(w, "<html><head></head><body>%s</body></html>", reflection)
+	} else {
+		fmt.Fprint(w, content)
 	}
 }
 

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -241,7 +241,8 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Server", domain)
 
-	content, ok := h.contents[strings.TrimPrefix(req.URL.Path, "/")]
+	filename := strings.TrimPrefix(req.URL.Path, "/")
+	content, ok := h.contents[filename]
 	if !ok {
 		content = h.contents["index.html"]
 	}
@@ -257,7 +258,7 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 	} else if reflection != "" {
 		fmt.Fprintf(w, "<html><head></head><body>%s</body></html>", reflection)
 	} else {
-		fmt.Fprint(w, content)
+		http.ServeContent(w, req, filename, time.Now(), strings.NewReader(content))
 	}
 }
 

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -40,6 +40,9 @@ func (l *noopLogger) Write(p []byte) (n int, err error) {
 // NewHTTPServer returns a new TLS & Non-TLS HTTP server.
 func NewHTTPServer(options *Options) (*HTTPServer, error) {
 	server := &HTTPServer{options: options, contents: make(map[string]string)}
+	if err := server.readIndexContents(options); err != nil {
+		return nil, errors.Wrap(err, "could not read index contents")
+	}
 
 	router := &http.ServeMux{}
 	router.Handle("/", server.logger(http.HandlerFunc(server.defaultHandler)))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -83,6 +83,10 @@ type Options struct {
 	PrivateKeyPath string
 	// HTTP header containing origin IP
 	OriginIPHeader string
+	// HTTPIndex is the http index file for server
+	HTTPIndex string
+	// HTTPDirectory is the directory for interact server
+	HTTPDirectory string
 
 	ACMEStore *acme.Provider
 }


### PR DESCRIPTION
Added `http-index` and `http-directory` flags to allow specifying either a user-supplied index file or directory for HTTP server. In case the user specifies a known file or '/' or index.html, the root page is displayed from either of these arguments or the banner.