### PR TITLE
Added static file and directory server

### DIFF
--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -37,6 +37,8 @@ func main() {
 
 	flagSet.CreateGroup("config", "config",
 		flagSet.StringVar(&cliOptions.Config, "config", defaultConfigLocation, "flag configuration file"),
+		flagSet.StringVarP(&cliOptions.HTTPIndex, "http-index", "hi", "", "custom index file for http server"),
+		flagSet.StringVarP(&cliOptions.HTTPDirectory, "http-directory", "hd", "", "directory with files to serve with http server"),
 	)
 
 	flagSet.CreateGroup("input", "Input",
@@ -225,7 +227,7 @@ func main() {
 
 	httpServer, err := server.NewHTTPServer(serverOptions)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create HTTP server")
+		gologger.Fatal().Msgf("Could not create HTTP server: %s", err)
 	}
 	httpAlive := make(chan bool)
 	httpsAlive := make(chan bool)
@@ -233,7 +235,7 @@ func main() {
 
 	smtpServer, err := server.NewSMTPServer(serverOptions)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create SMTP server")
+		gologger.Fatal().Msgf("Could not create SMTP server: %s", err)
 	}
 	smtpAlive := make(chan bool)
 	smtpsAlive := make(chan bool)
@@ -242,7 +244,7 @@ func main() {
 	ldapAlive := make(chan bool)
 	ldapServer, err := server.NewLDAPServer(serverOptions, cliOptions.LdapWithFullLogger)
 	if err != nil {
-		gologger.Fatal().Msgf("Could not create LDAP server")
+		gologger.Fatal().Msgf("Could not create LDAP server: %s", err)
 	}
 	go ldapServer.ListenAndServe(tlsConfig, ldapAlive)
 	defer ldapServer.Close()
@@ -251,7 +253,7 @@ func main() {
 	if cliOptions.Ftp {
 		ftpServer, err := server.NewFTPServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create FTP server")
+			gologger.Fatal().Msgf("Could not create FTP server: %s", err)
 		}
 		go ftpServer.ListenAndServe(tlsConfig, ftpAlive) //nolint
 	}
@@ -260,7 +262,7 @@ func main() {
 	if cliOptions.Responder {
 		responderServer, err := server.NewResponderServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create SMB server")
+			gologger.Fatal().Msgf("Could not create SMB server: %s", err)
 		}
 		go responderServer.ListenAndServe(responderAlive) //nolint
 		defer responderServer.Close()
@@ -270,7 +272,7 @@ func main() {
 	if cliOptions.Smb {
 		smbServer, err := server.NewSMBServer(serverOptions)
 		if err != nil {
-			gologger.Fatal().Msgf("Could not create SMB server")
+			gologger.Fatal().Msgf("Could not create SMB server: %s", err)
 		}
 		go smbServer.ListenAndServe(smbAlive) //nolint
 		defer smbServer.Close()

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -62,6 +62,7 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		HTTPIndex:                cliServerOptions.HTTPIndex,
 		HTTPDirectory:            cliServerOptions.HTTPDirectory,
 		Token:                    cliServerOptions.Token,
+		Version:                  Version,
 		OriginURL:                cliServerOptions.OriginURL,
 		RootTLD:                  cliServerOptions.RootTLD,
 		FTPDirectory:             cliServerOptions.FTPDirectory,

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -28,6 +28,8 @@ type CLIServerOptions struct {
 	LdapPort                 int
 	Ftp                      bool
 	Auth                     bool
+	HTTPIndex                string
+	HTTPDirectory            string
 	Token                    string
 	OriginURL                string
 	RootTLD                  bool
@@ -57,6 +59,8 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		FtpPort:                  cliServerOptions.FtpPort,
 		LdapPort:                 cliServerOptions.LdapPort,
 		Auth:                     cliServerOptions.Auth,
+		HTTPIndex:                cliServerOptions.HTTPIndex,
+		HTTPDirectory:            cliServerOptions.HTTPDirectory,
 		Token:                    cliServerOptions.Token,
 		OriginURL:                cliServerOptions.OriginURL,
 		RootTLD:                  cliServerOptions.RootTLD,

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -52,11 +52,13 @@ func NewHTTPServer(options *Options) (*HTTPServer, error) {
 
 	// If a static directory is specified, also serve it.
 	if options.HTTPDirectory != "" {
+		gologger.Info().Msgf("Loading directory (%s) to serve from : %s/s/", options.HTTPDirectory, strings.Join(options.Domains, ","))
 		server.staticHandler = http.StripPrefix("/s/", disableDirectoryListing(http.FileServer(http.Dir(options.HTTPDirectory))))
 	}
 	// If custom index, read the custom index file and serve it.
 	// Supports {DOMAIN} placeholders.
 	if options.HTTPIndex != "" {
+		gologger.Info().Msgf("Using custom server index: %s", options.HTTPIndex)
 		if data, err := ioutil.ReadFile(options.HTTPIndex); err == nil {
 			server.customBanner = string(data)
 		}
@@ -231,6 +233,7 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	w.Header().Set("Server", domain)
+	w.Header().Set("X-Interactsh-Version", h.options.Version)
 
 	if stringsutil.HasPrefixI(req.URL.Path, "/s/") && h.staticHandler != nil {
 		h.staticHandler.ServeHTTP(w, req)

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -52,13 +53,15 @@ func NewHTTPServer(options *Options) (*HTTPServer, error) {
 
 	// If a static directory is specified, also serve it.
 	if options.HTTPDirectory != "" {
-		gologger.Info().Msgf("Loading directory (%s) to serve from : %s/s/", options.HTTPDirectory, strings.Join(options.Domains, ","))
+		abs, _ := filepath.Abs(options.HTTPDirectory)
+		gologger.Info().Msgf("Loading directory (%s) to serve from : %s/s/", abs, strings.Join(options.Domains, ","))
 		server.staticHandler = http.StripPrefix("/s/", disableDirectoryListing(http.FileServer(http.Dir(options.HTTPDirectory))))
 	}
 	// If custom index, read the custom index file and serve it.
 	// Supports {DOMAIN} placeholders.
 	if options.HTTPIndex != "" {
-		gologger.Info().Msgf("Using custom server index: %s", options.HTTPIndex)
+		abs, _ := filepath.Abs(options.HTTPDirectory)
+		gologger.Info().Msgf("Using custom server index: %s", abs)
 		if data, err := ioutil.ReadFile(options.HTTPIndex); err == nil {
 			server.customBanner = string(data)
 		}

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -39,7 +39,7 @@ func (l *noopLogger) Write(p []byte) (n int, err error) {
 // disableDirectoryListing disables directory listing on http.FileServer
 func disableDirectoryListing(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/") {
+		if strings.HasSuffix(r.URL.Path, "/") || r.URL.Path == "" {
 			http.NotFound(w, r)
 			return
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,6 +87,8 @@ type Options struct {
 	PrivateKeyPath string
 	// HTTP header containing origin IP
 	OriginIPHeader string
+	// Version is the version of interactsh server
+	Version string
 
 	ACMEStore *acme.Provider
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,6 +63,10 @@ type Options struct {
 	Storage *storage.Storage
 	// Auth requires client to authenticate
 	Auth bool
+	// HTTPIndex is the http index file for server
+	HTTPIndex string
+	// HTTPDirectory is the directory for interact server
+	HTTPDirectory string
 	// Token required to retrieve interactions
 	Token string
 	// Enable root tld interactions


### PR DESCRIPTION
Closes #320. 

- Serves custom index pages with `-http-index` flag. Supports `{DOMAIN}` placeholder as dynamic variable.
- Serves custom directories under `/s/` prefix. Uses a go `http.Dir` implementation to serve the directories.

Examples -

```bash
# Serve interactsh server with custom directory
$ ./interactsh-server -d test.com -http-directory /root/interactsh/cmd/interactsh-server/static

# Serve interactsh server with custom banner
$ ./interactsh-server -d test.com -http-index banner.html
```

```console
./interactsh-server -d hackwithautomation.com -hd . -hi banner.html 

    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/ 1.0.5

		projectdiscovery.io

[INF] Public IP: 157.230.223.165
[INF] Outbound IP: 157.230.223.165
[INF] Loading existing SSL Certificate for:  [*.hackwithautomation.com, hackwithautomation.com]
[INF] Loading directory (/root/interactsh/cmd/interactsh-server) to serve from : hackwithautomation.com/s/
[INF] Using custom server index: /root/interactsh/cmd/interactsh-server
[INF] Listening with the following services:
[HTTP] Listening on TCP 157.230.223.165:80
[SMTPS] Listening on TCP 157.230.223.165:587
[SMTP] Listening on TCP 157.230.223.165:25
[DNS] Listening on UDP 157.230.223.165:53
[HTTPS] Listening on TCP 157.230.223.165:443
[LDAP] Listening on TCP 157.230.223.165:389
[DNS] Listening on TCP 157.230.223.165:53
```