### PR TITLE
Added dynamic response body support to HTTP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - AES encryption with zero logging
 - Automatic ACME based Wildcard TLS w/ Auto Renewal
 - DNS Entries for Cloud Metadata service
+- Dynamic HTTP Response control
 - Self-Hosted Interactsh Server
 - Multiple domain support **(self-hosted)**
 - NTLM/SMB/FTP/RESPONDER Listener **(self-hosted)**
@@ -483,8 +484,8 @@ The following query parameter names are supported - `body`, `header`, `status` a
 - **status** (response status code)
 - **delay** (response time)
 
-```
-curl -i 'https://ccg7b542vtc0000730kgggedi1hyyyyyb.hackwithautomation.com/?status=307&body=this+is+example+body&delay=1&header=header1:value1&header=header1:value12'
+```console
+curl -i 'https://hackwithautomation.com/x?status=307&body=this+is+example+body&delay=1&header=header1:value1&header=header1:value12'
 
 HTTP/2 307 
 header1: value1
@@ -497,6 +498,12 @@ date: Tue, 13 Sep 2022 12:31:05 GMT
 
 this is example body
 ```
+
+> **Note**:
+
+- Dynamic HTTP Response feature is disabled as default.
+- By design, this feature lets anyone run client-side code / redirects using your interactsh domain / server
+- Using this option with an isolated domain is recommended to **avoid security impact** on associated root/subdomains.
 
 ## Wildcard Interaction
 

--- a/README.md
+++ b/README.md
@@ -472,6 +472,32 @@ interactsh-server -d hackwithautomation.com -http-directory ./paylods
 
 ![image](https://user-images.githubusercontent.com/8293321/179396480-d5ff8399-8b91-48aa-b21f-c67e40e80945.png)
 
+## Dynamic HTTP Response
+
+Interactsh http server optionally enables responding with dynamic HTTP response by using query parameters. This feature can be enabled by using `-dr` or `-dynamic-resp` flag.
+
+The following query parameter names are supported - `body`, `header`, `status` and `delay`. Multiple `header` parameters can be specified to set multiple headers. 
+
+- **body** (response body)
+- **header** (response header)
+- **status** (response status code)
+- **delay** (response time)
+
+```
+curl -i 'https://ccg7b542vtc0000730kgggedi1hyyyyyb.hackwithautomation.com/?status=307&body=this+is+example+body&delay=1&header=header1:value1&header=header1:value12'
+
+HTTP/2 307 
+header1: value1
+header1: value12
+server: hackwithautomation.com
+x-interactsh-version: 1.0.7
+content-type: text/plain; charset=utf-8
+content-length: 20
+date: Tue, 13 Sep 2022 12:31:05 GMT
+
+this is example body
+```
+
 ## Wildcard Interaction
 
 To enable `wildcard` interaction for configured Interactsh domain `wildcard` flag can be used with implicit authentication protection via the `auth` flag if the `token` flag is omitted.

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -60,6 +60,7 @@ func main() {
 
 	flagSet.CreateGroup("config", "config",
 		flagSet.StringVar(&cliOptions.Config, "config", defaultConfigLocation, "flag configuration file"),
+		flagSet.BoolVarP(&cliOptions.DynamicResp, "dynamic-resp", "dr", false, "enable setting up arbitrary response data"),
 		flagSet.StringVarP(&cliOptions.CustomRecords, "custom-records", "cr", "", "custom dns records YAML file for DNS server"),
 		flagSet.StringVarP(&cliOptions.HTTPIndex, "http-index", "hi", "", "custom index file for http server"),
 		flagSet.StringVarP(&cliOptions.HTTPDirectory, "http-directory", "hd", "", "directory with files to serve with http server"),

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -35,6 +35,7 @@ type CLIServerOptions struct {
 	RootTLD                  bool
 	FTPDirectory             string
 	SkipAcme                 bool
+	DynamicResp              bool
 	CorrelationIdLength      int
 	CorrelationIdNonceLength int
 	ScanEverywhere           bool
@@ -68,6 +69,7 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		HTTPDirectory:            cliServerOptions.HTTPDirectory,
 		Token:                    cliServerOptions.Token,
 		Version:                  Version,
+		DynamicResp:              cliServerOptions.DynamicResp,
 		OriginURL:                cliServerOptions.OriginURL,
 		RootTLD:                  cliServerOptions.RootTLD,
 		FTPDirectory:             cliServerOptions.FTPDirectory,

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -296,7 +296,7 @@ func writeResponseFromDynamicRequest(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(parsed)
 	}
 	if body := values.Get("body"); body != "" {
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}
 }
 

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteResponseFromDynamicRequest(t *testing.T) {
+	t.Run("status", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://example.com/?status=404", nil)
+		w := httptest.NewRecorder()
+		writeResponseFromDynamicRequest(w, req)
+
+		resp := w.Result()
+		require.Equal(t, 404, resp.StatusCode, "could not get correct result")
+	})
+	t.Run("delay", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://example.com/?delay=1", nil)
+		w := httptest.NewRecorder()
+		now := time.Now()
+		writeResponseFromDynamicRequest(w, req)
+		took := time.Since(now)
+
+		require.Greater(t, took, 1*time.Second, "could not get correct delay")
+	})
+	t.Run("body", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://example.com/?body=this+is+example+body", nil)
+		w := httptest.NewRecorder()
+		writeResponseFromDynamicRequest(w, req)
+
+		resp := w.Result()
+		body, _ := ioutil.ReadAll(resp.Body)
+		require.Equal(t, "this is example body", string(body), "could not get correct result")
+	})
+	t.Run("header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://example.com/?header=Key:value&header=Test:Another", nil)
+		w := httptest.NewRecorder()
+		writeResponseFromDynamicRequest(w, req)
+
+		resp := w.Result()
+		require.Equal(t, resp.Header.Get("Key"), "value", "could not get correct result")
+		require.Equal(t, resp.Header.Get("Test"), "Another", "could not get correct result")
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,6 +95,8 @@ type Options struct {
 	DiskStorage bool
 	// DiskStoragePath defines the disk storage location
 	DiskStoragePath string
+	// DynamicResp enables dynamic HTTP response
+	DynamicResp bool
 	// EnableMetrics enables metrics endpoint
 	EnableMetrics bool
 


### PR DESCRIPTION
Closes #364 

Dynamic HTTP request example - 

```
> GET /?body=test&header=Key:value&status=404 HTTP/2
> Host: ccfn5rvkobjgg3eaq0h0at95rftfji6p3.domain.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
< HTTP/2 404
< key: value
< server: domain.com
< x-interactsh-version: 1.0.7
< content-type: text/plain; charset=utf-8
< content-length: 4
< date: Mon, 12 Sep 2022 17:58:44 GMT
<
{ [4 bytes data]
```