### PR TITLE
Fixing data race in file watcher

### DIFF
--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/gologger"
@@ -32,7 +33,7 @@ func (f *FileWatcher) Watch() (chan string, error) {
 		return nil, errors.New("file doesn't exist")
 	}
 	go func() {
-		lines := make(map[string]struct{})
+		var seenLines sync.Map
 		for range f.watcher.C {
 			r, err := os.Open(f.Options.File)
 			if err != nil {
@@ -42,9 +43,8 @@ func (f *FileWatcher) Watch() (chan string, error) {
 			sc := bufio.NewScanner(r)
 			for sc.Scan() {
 				data := sc.Text()
-				_, ok := lines[data]
-				if !ok {
-					lines[data] = struct{}{}
+				_, loaded := seenLines.LoadOrStore(data, struct{}{})
+				if !loaded {
 					out <- data
 				}
 

--- a/pkg/server/acme/records_store.go
+++ b/pkg/server/acme/records_store.go
@@ -24,11 +24,7 @@ func NewProvider() *Provider {
 }
 
 func (p *Provider) getZoneRecords(ctx context.Context, zoneName string) *RecordStore {
-	records, found := p.recordMap[zoneName]
-	if !found {
-		return nil
-	}
-	return records
+	return p.recordMap[zoneName]
 }
 
 func compareRecords(a, b libdns.Record) bool {


### PR DESCRIPTION
Fixing rare potential data race in file watcher when responder is used

Closes #460 

Investigation result: with a consistent load no other data races were detected with `go run -race`