### PR TITLE
feat: add custom server header + optional hide version header

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ DEBUG:
    -health-check, -hc  run diagnostic check up
    -metrics            enable metrics endpoint
    -v, -verbose        display verbose interaction
-   -server-token       show version of Interactsh in response HTTP headers
+   -no-version-header  hide version of Interactsh in response HTTP headers
 ```
 
 We are using GoDaddy for domain name and DigitalOcean droplet for the server, a basic $5 droplet should be sufficient to run self-hosted Interactsh server. If you are not using GoDaddy, follow your registrar's process for creating / updating DNS entries.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ CONFIG:
    -hd, -http-directory string  directory with files to serve with http server
    -ds, -disk                   disk based storage
    -dsp, -disk-path string      disk storage path
-   -header-server string        custom value of Server header in response
+   -csh, -server-header string  custom value of Server header in response
+   -dv, -disable-version        disable publishing interactsh version in response header
 
 UPDATE:
    -up, -update                 update interactsh-server to latest version
@@ -362,7 +363,6 @@ DEBUG:
    -health-check, -hc  run diagnostic check up
    -metrics            enable metrics endpoint
    -v, -verbose        display verbose interaction
-   -no-version-header  hide version of Interactsh in response HTTP headers
 ```
 
 We are using GoDaddy for domain name and DigitalOcean droplet for the server, a basic $5 droplet should be sufficient to run self-hosted Interactsh server. If you are not using GoDaddy, follow your registrar's process for creating / updating DNS entries.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ CONFIG:
    -hd, -http-directory string  directory with files to serve with http server
    -ds, -disk                   disk based storage
    -dsp, -disk-path string      disk storage path
+   -header-server string        custom value of Server header in response
 
 UPDATE:
    -up, -update                 update interactsh-server to latest version
@@ -361,6 +362,7 @@ DEBUG:
    -health-check, -hc  run diagnostic check up
    -metrics            enable metrics endpoint
    -v, -verbose        display verbose interaction
+   -server-token       show version of Interactsh in response HTTP headers
 ```
 
 We are using GoDaddy for domain name and DigitalOcean droplet for the server, a basic $5 droplet should be sufficient to run self-hosted Interactsh server. If you are not using GoDaddy, follow your registrar's process for creating / updating DNS entries.
@@ -466,8 +468,8 @@ interactsh-server -d oast.pro,oast.me
 
 While running interactsh server on **Cloud VM**'s like Amazon EC2, Goolge Cloud Platform (GCP), it is required to update the security rules to allow **"all traffic"** for inbound connections.
 
-</table>
 </td>
+</table>
 
 There are more useful capabilities supported by `interactsh-server` that are not enabled by default and are intended to be used only by **self-hosted** servers.
 

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -101,7 +101,7 @@ func main() {
 		flagSet.BoolVarP(&healthcheck, "hc", "health-check", false, "run diagnostic check up"),
 		flagSet.BoolVar(&cliOptions.EnableMetrics, "metrics", false, "enable metrics endpoint"),
 		flagSet.BoolVarP(&cliOptions.Verbose, "verbose", "v", false, "display verbose interaction"),
-		flagSet.BoolVar(&cliOptions.ServerToken, "server-token", false, "show version of Interactsh in response HTTP headers"),
+		flagSet.BoolVar(&cliOptions.NoVersionHeader, "no-version-header", false, "hide version of Interactsh in response HTTP headers"),
 	)
 
 	if err := flagSet.Parse(); err != nil {

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -68,7 +68,8 @@ func main() {
 		flagSet.StringVarP(&cliOptions.HTTPDirectory, "http-directory", "hd", "", "directory with files to serve with http server"),
 		flagSet.BoolVarP(&cliOptions.DiskStorage, "disk", "ds", false, "disk based storage"),
 		flagSet.StringVarP(&cliOptions.DiskStoragePath, "disk-path", "dsp", "", "disk storage path"),
-		flagSet.StringVar(&cliOptions.HeaderServer, "header-server", "", "custom value of Server header in response"),
+		flagSet.StringVarP(&cliOptions.HeaderServer, "server-header", "csh", "", "custom value of Server header in response"),
+		flagSet.BoolVarP(&cliOptions.NoVersionHeader, "disable-version", "dv", false, "disable publishing interactsh version in response header"),
 	)
 
 	flagSet.CreateGroup("update", "Update",
@@ -101,7 +102,6 @@ func main() {
 		flagSet.BoolVarP(&healthcheck, "hc", "health-check", false, "run diagnostic check up"),
 		flagSet.BoolVar(&cliOptions.EnableMetrics, "metrics", false, "enable metrics endpoint"),
 		flagSet.BoolVarP(&cliOptions.Verbose, "verbose", "v", false, "display verbose interaction"),
-		flagSet.BoolVar(&cliOptions.NoVersionHeader, "no-version-header", false, "hide version of Interactsh in response HTTP headers"),
 	)
 
 	if err := flagSet.Parse(); err != nil {

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -68,6 +68,7 @@ func main() {
 		flagSet.StringVarP(&cliOptions.HTTPDirectory, "http-directory", "hd", "", "directory with files to serve with http server"),
 		flagSet.BoolVarP(&cliOptions.DiskStorage, "disk", "ds", false, "disk based storage"),
 		flagSet.StringVarP(&cliOptions.DiskStoragePath, "disk-path", "dsp", "", "disk storage path"),
+		flagSet.StringVar(&cliOptions.HeaderServer, "header-server", "", "custom value of Server header in response"),
 	)
 
 	flagSet.CreateGroup("update", "Update",
@@ -100,6 +101,7 @@ func main() {
 		flagSet.BoolVarP(&healthcheck, "hc", "health-check", false, "run diagnostic check up"),
 		flagSet.BoolVar(&cliOptions.EnableMetrics, "metrics", false, "enable metrics endpoint"),
 		flagSet.BoolVarP(&cliOptions.Verbose, "verbose", "v", false, "display verbose interaction"),
+		flagSet.BoolVar(&cliOptions.ServerToken, "server-token", false, "show version of Interactsh in response HTTP headers"),
 	)
 
 	if err := flagSet.Parse(); err != nil {

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -50,7 +50,7 @@ type CLIServerOptions struct {
 	EnableMetrics            bool
 	Verbose                  bool
 	DisableUpdateCheck       bool
-	ServerToken              bool
+	NoVersionHeader          bool
 	HeaderServer             string
 }
 
@@ -88,7 +88,7 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		DiskStorage:              cliServerOptions.DiskStorage,
 		DiskStoragePath:          cliServerOptions.DiskStoragePath,
 		EnableMetrics:            cliServerOptions.EnableMetrics,
-		ServerToken:              cliServerOptions.ServerToken,
+		NoVersionHeader:          cliServerOptions.NoVersionHeader,
 		HeaderServer:             cliServerOptions.HeaderServer,
 	}
 }

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -88,5 +88,7 @@ func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {
 		DiskStorage:              cliServerOptions.DiskStorage,
 		DiskStoragePath:          cliServerOptions.DiskStoragePath,
 		EnableMetrics:            cliServerOptions.EnableMetrics,
+		ServerToken:              cliServerOptions.ServerToken,
+		HeaderServer:             cliServerOptions.HeaderServer,
 	}
 }

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -50,6 +50,8 @@ type CLIServerOptions struct {
 	EnableMetrics            bool
 	Verbose                  bool
 	DisableUpdateCheck       bool
+	ServerToken              bool
+	HeaderServer             string
 }
 
 func (cliServerOptions *CLIServerOptions) AsServerOptions() *server.Options {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -221,13 +221,13 @@ If you notice any interactions from <b>*.%s</b> in your logs, it's possible that
 You should investigate the sites where these interactions were generated from, and if a vulnerability exists, examine the root cause and take the necessary steps to mitigate the issue.
 `
 
-// defaultHandler is a handler for default collaborator requests
-func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
-	atomic.AddUint64(&h.options.Stats.Http, 1)
+func extractServerDomain(h *HTTPServer, req *http.Request) string {
+	if h.options.HeaderServer != "" {
+		return h.options.HeaderServer
+	}
 
-	reflection := h.options.URLReflection(req.Host)
-	// use first domain as default (todo: should be extracted from certificate)
 	var domain string
+	// use first domain as default (todo: should be extracted from certificate)
 	if len(h.options.Domains) > 0 {
 		// attempts to extract the domain name from host header
 		for _, configuredDomain := range h.options.Domains {
@@ -241,9 +241,20 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 			domain = h.options.Domains[0]
 		}
 	}
-	w.Header().Set("Server", domain)
-	w.Header().Set("X-Interactsh-Version", h.options.Version)
+	return domain
+}
 
+// defaultHandler is a handler for default collaborator requests
+func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
+	atomic.AddUint64(&h.options.Stats.Http, 1)
+
+	domain := extractServerDomain(h, req)
+	w.Header().Set("Server", domain)
+	if h.options.ServerToken {
+		w.Header().Set("X-Interactsh-Version", h.options.Version)
+	}
+
+	reflection := h.options.URLReflection(req.Host)
 	if stringsutil.HasPrefixI(req.URL.Path, "/s/") && h.staticHandler != nil {
 		h.staticHandler.ServeHTTP(w, req)
 	} else if req.URL.Path == "/" && reflection == "" {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -250,7 +250,7 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 
 	domain := extractServerDomain(h, req)
 	w.Header().Set("Server", domain)
-	if h.options.ServerToken {
+	if !h.options.NoVersionHeader {
 		w.Header().Set("X-Interactsh-Version", h.options.Version)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,6 +100,10 @@ type Options struct {
 	DynamicResp bool
 	// EnableMetrics enables metrics endpoint
 	EnableMetrics bool
+	// ServerToken enables show server version in HTTP response X-Interactsh-Version header
+	ServerToken bool
+	// HeaderServer use custom string in HTTP response Server header instead of domain
+	HeaderServer string
 
 	ACMEStore *acme.Provider
 	Stats     *Metrics

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,8 +100,8 @@ type Options struct {
 	DynamicResp bool
 	// EnableMetrics enables metrics endpoint
 	EnableMetrics bool
-	// ServerToken enables show server version in HTTP response X-Interactsh-Version header
-	ServerToken bool
+	// ServerToken hide server version in HTTP response X-Interactsh-Version header
+	NoVersionHeader bool
 	// HeaderServer use custom string in HTTP response Server header instead of domain
 	HeaderServer string
 


### PR DESCRIPTION
1. Add `-server-token` to control if interactsh-server version to be show in response http header.
2. Add `-header-server` to define custom header `Server` in response.

Link: #511 