### PR TITLE
add ACAO headers to root endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.devcontainer
 
 cmd/interactsh-server/interactsh-server
 cmd/interactsh-client/interactsh-client

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -69,7 +69,7 @@ func NewHTTPServer(options *Options) (*HTTPServer, error) {
 		}
 	}
 	router := &http.ServeMux{}
-	router.Handle("/", server.logger(http.HandlerFunc(server.defaultHandler)))
+	router.Handle("/", server.logger(server.corsMiddleware(http.HandlerFunc(server.defaultHandler))))
 	router.Handle("/register", server.corsMiddleware(server.authMiddleware(http.HandlerFunc(server.registerHandler))))
 	router.Handle("/deregister", server.corsMiddleware(server.authMiddleware(http.HandlerFunc(server.deregisterHandler))))
 	router.Handle("/poll", server.corsMiddleware(server.authMiddleware(http.HandlerFunc(server.pollHandler))))


### PR DESCRIPTION
Closes #441.

```console
$ go run main.go -d test

    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/

                projectdiscovery.io

[INF] Current interactsh version 1.1.6 (latest)
[INF] Public IP: X.X.X.X
[INF] Outbound IP: 172.17.0.3
1.6947870352740743e+09  info    maintenance     started background certificate maintenance      {"cache": "0x4000480880"}
[INF] Requesting SSL Certificate for:  [*.test, test]
1.6947870352760246e+09  info    obtain  acquiring lock  {"identifier": "*.test"}
1.6947870353403864e+09  info    obtain  lock acquired   {"identifier": "*.test"}
1.6947870353405929e+09  info    obtain  obtaining certificate   {"identifier": "*.test"}
1.694787035341121e+09   info    obtain  releasing lock  {"identifier": "*.test"}
[ERR] An error occurred while applying for a certificate, error: [*.test] Obtain: subject does not qualify for a public certificate: *.test
[ERR] Could not generate certs for auto TLS, https will be disabled
[INF] Listening with the following services:
[DNS] Listening on UDP 172.17.0.3:53
[HTTP] Listening on TCP 172.17.0.3:80
[DNS] Listening on TCP 172.17.0.3:53
[LDAP] Listening on TCP 172.17.0.3:389
[SMTPS] Listening on TCP 172.17.0.3:587
[SMTP] Listening on TCP 172.17.0.3:25
[HTTPS] Listening on TCP 172.17.0.3:443
[ERR] Could not serve http on tls: open : no such file or directory
```

```console
$ curl -I 172.17.0.3
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Server: test
X-Interactsh-Version: 1.1.6
Date: Fri, 15 Sep 2023 14:13:41 GMT
Content-Length: 646
```