### PR TITLE
introduce base64 body query param

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"net"
@@ -308,6 +309,13 @@ func writeResponseFromDynamicRequest(w http.ResponseWriter, req *http.Request) {
 	}
 	if body := values.Get("body"); body != "" {
 		_, _ = w.Write([]byte(body))
+	}
+
+	if b64Body := values.Get("b64_body"); b64Body != "" {
+		fmt.Println(b64Body)
+		if body, err := base64.StdEncoding.DecodeString(b64Body); err == nil {
+			_, _ = w.Write(body)
+		}
 	}
 }
 


### PR DESCRIPTION
### Proposal:
https://github.com/projectdiscovery/interactsh#dynamic-http-response supports `body` parameter to set custom response; an additional parameter needs to be supported to accept base64 encoded input to set complex/binary responses that can not be set using plain text input. 


**Example:**

```console
curl -i 'https://hackwithautomation.com/x?b64_body =dGhpcyBpcyBleGFtcGxlIGJvZHk='

HTTP/2 200
server: hackwithautomation.com
x-interactsh-version: 1.0.7
content-type: text/plain; charset=utf-8
content-length: 20
date: Tue, 13 Sep 2022 12:31:05 GMT

this is example body
```


### use case:
- Ability to set binary response for complex exploit/template development.


Closes #685.