### PR TITLE
add dynamic headers , status and delay  to work with http-directory

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -266,12 +266,14 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 				}
 			}
 			if delay := values.Get("delay"); delay != "" {
-				parsed, _ := strconv.Atoi(delay)
-				time.Sleep(time.Duration(parsed) * time.Second)
+				if parsed, err := strconv.Atoi(delay); err == nil {
+					time.Sleep(time.Duration(parsed) * time.Second)
+				}
 			}
 			if status := values.Get("status"); status != "" {
-				parsed, _ := strconv.Atoi(status)
-				w.WriteHeader(parsed)
+				if parsed, err := strconv.Atoi(status); err == nil {
+					w.WriteHeader(parsed)
+				}
 			}
 		}
 		h.staticHandler.ServeHTTP(w, req)


### PR DESCRIPTION
#741 
I think we should make adding the headers, status and delay into a function with code from [writeResponseFromDynamicRequest](https://github.com/projectdiscovery/interactsh/blob/main/pkg/server/http_server.go#L292C6-L292C37) but i couldn't think of the best way to do it 