### PR TITLE
Fixing remote address info via log handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.21
 
 require (
 	git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a
-	github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/caddyserver/certmagic v0.19.2
 	github.com/docker/go-units v0.5.0
@@ -18,6 +17,7 @@ require (
 	github.com/projectdiscovery/asnmap v1.0.6
 	github.com/projectdiscovery/goflags v0.1.40
 	github.com/projectdiscovery/gologger v1.1.12
+	github.com/projectdiscovery/ldapserver v1.0.2-0.20240219154113-dcc758ebc0cb
 	github.com/projectdiscovery/retryabledns v1.0.56
 	github.com/projectdiscovery/retryablehttp-go v1.0.48
 	github.com/projectdiscovery/utils v0.0.78

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 h1:KFac3SiGbId8ub
 github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057/go.mod h1:iLB2pivrPICvLOuROKmlqURtFIEsoJZaMidQfCG1+D4=
 github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 h1:ZbFL+BDfBqegi+/Ssh7im5+aQfBRx6it+kHnC7jaDU8=
 github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809/go.mod h1:upgc3Zs45jBDnBT4tVRgRcgm26ABpaP7MoTSdgysca4=
-github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd h1:RTWs+wEY9efxTKK5aFic5C5KybqQelGcX+JdM69KoTo=
-github.com/Mzack9999/ldapserver v1.0.2-0.20211229000134-b44a0d6ad0dd/go.mod h1:AqtPw7WNT0O69k+AbPKWVGYeW94TqgMW/g+Ppc8AZr4=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
@@ -211,6 +209,8 @@ github.com/projectdiscovery/gologger v1.1.12 h1:uX/QkQdip4PubJjjG0+uk5DtyAi1ANPJ
 github.com/projectdiscovery/gologger v1.1.12/go.mod h1:DI8nywPLERS5mo8QEA9E7gd5HZ3Je14SjJBH3F5/kLw=
 github.com/projectdiscovery/hmap v0.0.39 h1:R33JJzPz8TMUm1TJQ/X5zVJbmyTS64EttZ085thq19g=
 github.com/projectdiscovery/hmap v0.0.39/go.mod h1:wEPoEIVGPdHsc9EnE+ERUdgNyp29zZn6gACOALylHOg=
+github.com/projectdiscovery/ldapserver v1.0.2-0.20240219154113-dcc758ebc0cb h1:MGtI4oE12ruWv11ZlPXXd7hl/uAaQZrFvrIDYDeVMd8=
+github.com/projectdiscovery/ldapserver v1.0.2-0.20240219154113-dcc758ebc0cb/go.mod h1:vmgC0DTFCfoCLp0RAfsfYTZZan0QMVs+cmTbH6blfjk=
 github.com/projectdiscovery/mapcidr v1.1.16 h1:rjj1w5D6hbTsUQXYClLcGdfBEy9bryclgi70t0vBggo=
 github.com/projectdiscovery/mapcidr v1.1.16/go.mod h1:rGqpBhStdwOQ2uS62QM9qPsybwMwIhT7CTd2bxoHs8Q=
 github.com/projectdiscovery/networkpolicy v0.0.7 h1:AwHqBRXBqDQgnWzBMuoJtHBNEYBw+NFp/4qIK688x7o=

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -8,17 +8,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	ldap "github.com/Mzack9999/ldapserver"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/gologger"
+	ldap "github.com/projectdiscovery/ldapserver"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
 // Most routes handlers are taken from the example at https://github.com/vjeantet/ldapserver/blob/master/examples/complex/main.go
-
-func init() {
-	ldap.Logger = ldap.DiscardingLogger
-}
 
 // LDAPServer is a ldap server instance
 type LDAPServer struct {
@@ -33,7 +29,7 @@ func NewLDAPServer(options *Options, withLogger bool) (*LDAPServer, error) {
 	ldapserver := &LDAPServer{options: options, WithLogger: withLogger}
 
 	if withLogger {
-		ldap.Logger = ldapserver
+		ldap.HandleLogCallback = ldapserver.handleLog
 	}
 
 	routes := ldap.NewRouteMux()
@@ -392,36 +388,7 @@ func (ldapServer *LDAPServer) handleExtended(w ldap.ResponseWriter, m *ldap.Mess
 	}
 }
 
-func (ldapServer *LDAPServer) Fatal(v ...interface{}) {
-	//nolint
-	ldapServer.handleLog("%v", v...) //nolint
-}
-func (ldapServer *LDAPServer) Fatalf(format string, v ...interface{}) {
-	ldapServer.handleLog(format, v...)
-}
-func (ldapServer *LDAPServer) Fatalln(v ...interface{}) {
-	ldapServer.handleLog("%v", v...) //nolint
-}
-func (ldapServer *LDAPServer) Panic(v ...interface{}) {
-	ldapServer.handleLog("%v", v...) //nolint
-}
-func (ldapServer *LDAPServer) Panicf(format string, v ...interface{}) {
-	ldapServer.handleLog(format, v...)
-}
-func (ldapServer *LDAPServer) Panicln(v ...interface{}) {
-	ldapServer.handleLog("%v", v...) //nolint
-}
-func (ldapServer *LDAPServer) Print(v ...interface{}) {
-	ldapServer.handleLog("%v", v...) //nolint
-}
-func (ldapServer *LDAPServer) Printf(format string, v ...interface{}) {
-	ldapServer.handleLog(format, v...)
-}
-func (ldapServer *LDAPServer) Println(v ...interface{}) {
-	ldapServer.handleLog("%v", v...) //nolint
-}
-
-func (ldapServer *LDAPServer) handleLog(f string, v ...interface{}) {
+func (ldapServer *LDAPServer) handleLog(host string, f string, v ...interface{}) {
 	// just discard logs if logger is disabled
 	if !ldapServer.WithLogger {
 		return
@@ -437,7 +404,7 @@ func (ldapServer *LDAPServer) handleLog(f string, v ...interface{}) {
 	}
 
 	// Correlation id doesn't apply here, we skip encryption
-	ldapServer.logInteraction(Interaction{RawRequest: data.String()})
+	ldapServer.logInteraction(Interaction{RawRequest: data.String(), RemoteAddress: host})
 }
 
 func (ldapServer *LDAPServer) logInteraction(interaction Interaction) {


### PR DESCRIPTION
```console
$ sudo go run . -ip 192.168.10.4 -lip 192.168.10.4 -d local.host -e 365 -t t0k3n -se -dr -dv -ldap -wc -ftp -verbose -debug -skip-acme

    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/

                projectdiscovery.io

[INF] Current interactsh version 1.1.9-dev (development)
[INF] Listening with the following services:
[LDAP] Listening on TCP 192.168.10.4:389
[HTTP] Listening on TCP 192.168.10.4:80
[FTP] Listening on TCP 192.168.10.4:21
[DNS] Listening on TCP 192.168.10.4:53
[DNS] Listening on UDP 192.168.10.4:53
[SMTP] Listening on TCP 192.168.10.4:25
[DBG] LDAP Interaction: 
{"protocol":"ldap","unique-id":"","full-id":"","raw-request":"Connection client [1] from 192.168.10.4:61840 accepted","remote-address":"192.168.10.4:61840","timestamp":"2024-02-19T16:42:44.998718+01:00"}
...
```