### PR TITLE
add err check

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -167,9 +167,10 @@ func New(options *Options) (*Client, error) {
 			client.privKey = privKey
 		}
 		pubKey, err := decodePublicKey(options.SessionInfo.PublicKey)
-		if err == nil {
-			client.pubKey = pubKey
+		if err != nil {
+			return nil, errorutil.NewWithErr(err).Msgf("failed to decode public key")
 		}
+		client.pubKey = pubKey
 		if serverURL, err := url.Parse(options.SessionInfo.ServerURL); err == nil {
 			client.serverURL = serverURL
 		}
@@ -280,6 +281,9 @@ func decodePublicKey(data string) (*rsa.PublicKey, error) {
 	}
 
 	pubkeyPem, _ := pem.Decode(decodedBytes)
+	if pubkeyPem == nil {
+		return nil, errors.New("failed to decode PEM block containing the public key")
+	}
 
 	pubKey, err := x509.ParsePKIXPublicKey(pubkeyPem.Bytes)
 	if err != nil {


### PR DESCRIPTION
Closes #806


```console
$ cat sess 
server-url: https://interact.sh
```

before:
```console
$ go run .  -sf sess

    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/

                projectdiscovery.io

[INF] Current interactsh version 1.1.9 (latest)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x10545ec7c]

goroutine 1 [running]:
github.com/projectdiscovery/interactsh/pkg/client.decodePublicKey({0x0?, 0x0?})
        /Users/fortytwo/Projects/interactsh/pkg/client/client.go:284 +0x3c
github.com/projectdiscovery/interactsh/pkg/client.New(0x140006d3ed0)
        /Users/fortytwo/Projects/interactsh/pkg/client/client.go:169 +0x44c
main.main()
        /Users/fortytwo/Projects/interactsh/cmd/interactsh-client/main.go:133 +0x13f0
exit status 2
```

after:
```console
$ go run .  -sf sess

    _       __                       __       __  
   (_)___  / /____  _________ ______/ /______/ /_ 
  / / __ \/ __/ _ \/ ___/ __ '/ ___/ __/ ___/ __ \
 / / / / / /_/  __/ /  / /_/ / /__/ /_(__  ) / / /
/_/_/ /_/\__/\___/_/   \__,_/\___/\__/____/_/ /_/

                projectdiscovery.io

[INF] Current interactsh version 1.1.9 (latest)
[FTL] Could not create client: [:RUNTIME] failed to decode public key <- failed to decode PEM block containing the public key
exit status 1
```

P.S. This was the only way I could repro the issue.