### PR TITLE
changes to disable LDAP and FTP in responder when they are used by "interactsh"

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ $ sudo interactsh-server -responder -d localhost
 On default settings, the daemon listens on the following ports:
 
 - UDP: 137, 138, 1434
-+ TCP: 21 (might collide with FTP daemon if used), 110, 135, 139, 389, 445, 1433, 3141, 3128
++ TCP: 21 (might collide with FTP daemon if used), 110, 135, 139, 389 (might collide with LDAP server), 445, 1433, 3141, 3128
 
 ## Interactsh Integration
 

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -85,7 +85,8 @@ func main() {
 		flagSet.IntVar(&cliOptions.SmtpsPort, "smtps-port", 587, "port to use for smtps service"),
 		flagSet.IntVar(&cliOptions.SmtpAutoTLSPort, "smtp-autotls-port", 465, "port to use for smtps autotls service"),
 		flagSet.IntVar(&cliOptions.LdapPort, "ldap-port", 389, "port to use for ldap service"),
-		flagSet.BoolVar(&cliOptions.LdapWithFullLogger, "ldap", false, "enable ldap server with full logging (authenticated)"),
+		flagSet.BoolVar(&cliOptions.Ldap, "ldap", true, "enable ldap server"),
+		flagSet.BoolVar(&cliOptions.LdapWithFullLogger, "ldapFullLog", false, "enable ldap server with full logging (authenticated)"),
 		flagSet.BoolVarP(&cliOptions.RootTLD, "wildcard", "wc", false, "enable wildcard interaction for interactsh domain (authenticated)"),
 		flagSet.BoolVar(&cliOptions.Smb, "smb", false, "start smb agent - impacket and python 3 must be installed (authenticated)"),
 		flagSet.BoolVar(&cliOptions.Responder, "responder", false, "start responder agent - docker must be installed (authenticated)"),
@@ -319,13 +320,14 @@ func main() {
 	go smtpServer.ListenAndServe(tlsConfig, smtpAlive, smtpsAlive)
 
 	ldapAlive := make(chan bool)
-	ldapServer, err := server.NewLDAPServer(serverOptions, cliOptions.LdapWithFullLogger)
-	if err != nil {
-		gologger.Fatal().Msgf("Could not create LDAP server: %s", err)
+	if cliOptions.Ldap {
+		ldapServer, err := server.NewLDAPServer(serverOptions, cliOptions.LdapWithFullLogger)
+		if err != nil {
+			gologger.Fatal().Msgf("Could not create LDAP server: %s", err)
+		}
+		go ldapServer.ListenAndServe(tlsConfig, ldapAlive)
+		defer ldapServer.Close()
 	}
-	go ldapServer.ListenAndServe(tlsConfig, ldapAlive)
-	defer ldapServer.Close()
-
 	ftpAlive := make(chan bool)
 	ftpsAlive := make(chan bool)
 	if cliOptions.Ftp {
@@ -338,7 +340,7 @@ func main() {
 
 	responderAlive := make(chan bool)
 	if cliOptions.Responder {
-		responderServer, err := server.NewResponderServer(serverOptions)
+		responderServer, err := server.NewResponderServer(serverOptions,cliOptions.Ldap,cliOptions.Ftp)
 		if err != nil {
 			gologger.Fatal().Msgf("Could not create SMB server: %s", err)
 		}

--- a/pkg/options/server_options.go
+++ b/pkg/options/server_options.go
@@ -17,6 +17,7 @@ type CLIServerOptions struct {
 	HttpsPort                int
 	Hostmasters              []string
 	LdapWithFullLogger       bool
+	Ldap       				 bool
 	Eviction                 int
 	NoEviction               bool
 	Responder                bool

--- a/pkg/server/responder_server.go
+++ b/pkg/server/responder_server.go
@@ -24,6 +24,8 @@ var responderMonitorList map[string]string = map[string]string{
 // ResponderServer is a Responder wrapper server instance
 type ResponderServer struct {
 	options   *Options
+	ldapInteract bool
+	ftpInteract  bool
 	LogFile   string
 	ipAddress net.IP
 	cmd       *exec.Cmd
@@ -31,9 +33,11 @@ type ResponderServer struct {
 }
 
 // NewResponderServer returns a new SMB server.
-func NewResponderServer(options *Options) (*ResponderServer, error) {
+func NewResponderServer(options *Options,LdapInteract bool,FtpInteract bool) (*ResponderServer, error) {
 	server := &ResponderServer{
 		options:   options,
+		ldapInteract:LdapInteract,
+		ftpInteract:FtpInteract,
 		ipAddress: net.ParseIP(options.IPAddress),
 	}
 	return server, nil
@@ -51,7 +55,14 @@ func (h *ResponderServer) ListenAndServe(responderAlive chan bool) error {
 	}
 	h.tmpFolder = tmpFolder
 	// execute dockerized responder
-	cmdLine := "docker run -p 137:137/udp -p  138:138/udp -p 389:389 -p 1433:1433 -p 1434:1434/udp -p 135:135 -p 139:139 -p 445:445 -p 21:21 -p 3141:3141 -p 110:110 -p 3128:3128 -p 5355:5355/udp -v " + h.tmpFolder + ":/opt/Responder/logs --rm interactsh:latest"
+	cmdLine := "docker run -p 137:137/udp -p  138:138/udp -p 1433:1433 -p 1434:1434/udp -p 135:135 -p 139:139 -p 445:445  -p 3141:3141 -p 110:110 -p 3128:3128 -p 5355:5355/udp"
+	if !h.ldapInteract{
+		cmdLine += " -p 389:389 "
+	}
+	if !h.ftpInteract{
+		cmdLine += " -p 21:21 "
+	}
+	cmdLine += " -v " + h.tmpFolder + ":/opt/Responder/logs --rm interactsh:latest"
 	args := strings.Fields(cmdLine)
 	h.cmd = exec.Command(args[0], args[1:]...)
 	err = h.cmd.Start()


### PR DESCRIPTION
Now if someone wants to use interact + responder (docker) it will fail and the responder docker does not start. This is because by default interactsh starts a LDAP server on port 389, and the default command for responder docker uses this port too. 
The "docker run" command fails and does not start.

There should be an option for disabling "interact"LDAP server completly so there is not ports conflicts with the "responder" command.

This change takes cares of this option, and changes the "docker run" command so there is no port conflicts with LDAP or FTP.