### PR TITLE
Enable loading of the default config file

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -133,6 +133,12 @@ func main() {
 		}
 	}
 
+	if fileutil.FileExists(defaultConfigLocation) {
+		if err := flagSet.MergeConfigFile(defaultConfigLocation); err != nil {
+			gologger.Fatal().Msgf("Could not read default config: %s\n", err)
+		}
+	}
+
 	if cliOptions.Config != defaultConfigLocation {
 		if err := flagSet.MergeConfigFile(cliOptions.Config); err != nil {
 			gologger.Fatal().Msgf("Could not read config: %s\n", err)

--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -133,13 +133,7 @@ func main() {
 		}
 	}
 
-	if fileutil.FileExists(defaultConfigLocation) {
-		if err := flagSet.MergeConfigFile(defaultConfigLocation); err != nil {
-			gologger.Fatal().Msgf("Could not read default config: %s\n", err)
-		}
-	}
-
-	if cliOptions.Config != defaultConfigLocation {
+	if fileutil.FileExists(cliOptions.Config) {
 		if err := flagSet.MergeConfigFile(cliOptions.Config); err != nil {
 			gologger.Fatal().Msgf("Could not read config: %s\n", err)
 		}


### PR DESCRIPTION
The default configuration file, located at "$HOME/.config/interactsh-client/config.yaml", is currently not loaded unless its path is explicitly specified with the -config option.

This PR allows the default configuration file to be automatically loaded, even if the -config option is not provided.