### PR TITLE
Allow custom banner on attack domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ Index page for http server can be customized while running custom interactsh ser
 interactsh-server -d hackwithautomation.com -http-index banner.html
 ```
 
+`{REFLECTION}` placeholder is supported in index file to replace with the inverted ID in case it exists.
 `{DOMAIN}` placeholder is also supported in index file to replace with server domain name.
 
 ![image](https://user-images.githubusercontent.com/8293321/179397016-f6ee12e0-5b0b-42b6-83e7-f0972a804655.png)

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -277,12 +277,11 @@ func (h *HTTPServer) defaultHandler(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 		h.staticHandler.ServeHTTP(w, req)
+	} else if req.URL.Path == "/" && h.customBanner != "" {
+		b := strings.ReplaceAll(h.customBanner, "{REFLECTION}", reflection)
+		fmt.Fprint(w, strings.ReplaceAll(b, "{DOMAIN}", domain))
 	} else if req.URL.Path == "/" && reflection == "" {
-		if h.customBanner != "" {
-			fmt.Fprint(w, strings.ReplaceAll(h.customBanner, "{DOMAIN}", domain))
-		} else {
-			fmt.Fprintf(w, banner, domain)
-		}
+		fmt.Fprintf(w, banner, domain)
 	} else if strings.EqualFold(req.URL.Path, "/robots.txt") {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: / # %s", reflection)
 	} else if stringsutil.HasSuffixI(req.URL.Path, ".json") {


### PR DESCRIPTION
I would expect to always get a custom banner on the index of all the subdomains when the `-http-index` is set. But that's not the current behavior. This is a solution that allow to keep the reflection of the inverted domain in the response and at the same time have the custom index page.

Use case:
I am trying to distinguish web clients, to do so I  add a custom HTML that may do extra interactions depending on the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom banners now support dynamic placeholder replacement for {REFLECTION} and {DOMAIN} values, enabling personalized banner content based on server configuration.

* **Documentation**
  * Updated documentation describing the {REFLECTION} and {DOMAIN} placeholder support in index file configuration, replacing with the inverted ID and server domain name respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->