### PR TITLE
fix: differentiate HTTP vs HTTPS protocol in interactions

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -150,7 +150,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 					ID := domain
 					host, _, _ := net.SplitHostPort(r.RemoteAddr)
 					interaction := &Interaction{
-						Protocol:      "http",
+						Protocol:      httpProtocol(r),
 						UniqueID:      r.Host,
 						FullId:        r.Host,
 						RawRequest:    reqString,
@@ -177,7 +177,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 				for part := range stringsutil.SlideWithLength(chunk, h.options.GetIdLength()) {
 					normalizedPart := strings.ToLower(part)
 					if h.options.isCorrelationID(normalizedPart) {
-						h.handleInteraction(normalizedPart, part, reqString, respString, host)
+						h.handleInteraction(r, normalizedPart, part, reqString, respString, host)
 					}
 				}
 			}
@@ -191,7 +191,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 						if i+1 <= len(parts) {
 							fullID = strings.Join(parts[:i+1], ".")
 						}
-						h.handleInteraction(normalizedPartChunk, fullID, reqString, respString, host)
+						h.handleInteraction(r, normalizedPartChunk, fullID, reqString, respString, host)
 					}
 				}
 			}
@@ -199,11 +199,18 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 	}
 }
 
-func (h *HTTPServer) handleInteraction(uniqueID, fullID, reqString, respString, hostPort string) {
+func httpProtocol(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func (h *HTTPServer) handleInteraction(r *http.Request, uniqueID, fullID, reqString, respString, hostPort string) {
 	correlationID := uniqueID[:h.options.CorrelationIdLength]
 
 	interaction := &Interaction{
-		Protocol:      "http",
+		Protocol:      httpProtocol(r),
 		UniqueID:      uniqueID,
 		FullId:        fullID,
 		RawRequest:    reqString,

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestHttpProtocol(t *testing.T) {
+	t.Run("plaintext", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "http://example.com/", nil)
+		require.Equal(t, "http", httpProtocol(r))
+	})
+	t.Run("tls", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "https://example.com/", nil)
+		r.TLS = &tls.ConnectionState{}
+		require.Equal(t, "https", httpProtocol(r))
+	})
+}
 
 func TestWriteResponseFromDynamicRequest(t *testing.T) {
 	t.Run("status", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Check `r.TLS != nil` to set interaction protocol to `"https"` when request arrives over TLS, instead of always using `"http"`
- Add `httpProtocol` helper and pass `*http.Request` to `handleInteraction`
- Add unit test covering both plaintext and TLS cases

Fixes #1290