### PR TITLE
fix: Consistently use overriden config paths with -config flag

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -86,6 +86,19 @@ func main() {
 		flagSet.BoolVarP(&healthcheck, "hc", "health-check", false, "run diagnostic check up"),
 	)
 
+	// If a custom config path is provided via -config, tell goflags before
+	// Parse() so it doesn't try to create/read the default config location.
+	for i := 1; i < len(os.Args); i++ {
+		if (os.Args[i] == "-config" || os.Args[i] == "--config") && i+1 < len(os.Args) {
+			flagSet.SetConfigFilePath(os.Args[i+1])
+			break
+		}
+		if strings.HasPrefix(os.Args[i], "-config=") || strings.HasPrefix(os.Args[i], "--config=") {
+			flagSet.SetConfigFilePath(strings.SplitN(os.Args[i], "=", 2)[1])
+			break
+		}
+	}
+
 	if err := flagSet.Parse(); err != nil {
 		gologger.Fatal().Msgf("Could not parse options: %s\n", err)
 	}
@@ -130,12 +143,6 @@ func main() {
 			}
 		} else {
 			gologger.Info().Msgf("Current interactsh version %v %v", options.Version, updateutils.GetVersionDescription(options.Version, latestVersion))
-		}
-	}
-
-	if fileutil.FileExists(cliOptions.Config) {
-		if err := flagSet.MergeConfigFile(cliOptions.Config); err != nil {
-			gologger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 	}
 

--- a/cmd/interactsh-server/main.go
+++ b/cmd/interactsh-server/main.go
@@ -110,6 +110,19 @@ func main() {
 		flagSet.BoolVarP(&cliOptions.Verbose, "verbose", "v", false, "display verbose interaction"),
 	)
 
+	// If a custom config path is provided via -config, tell goflags before
+	// Parse() so it doesn't try to create/read the default config location.
+	for i := 1; i < len(os.Args); i++ {
+		if (os.Args[i] == "-config" || os.Args[i] == "--config") && i+1 < len(os.Args) {
+			flagSet.SetConfigFilePath(os.Args[i+1])
+			break
+		}
+		if strings.HasPrefix(os.Args[i], "-config=") || strings.HasPrefix(os.Args[i], "--config=") {
+			flagSet.SetConfigFilePath(strings.SplitN(os.Args[i], "=", 2)[1])
+			break
+		}
+	}
+
 	if err := flagSet.Parse(); err != nil {
 		gologger.Fatal().Msgf("Could not parse options: %s\n", err)
 	}
@@ -133,12 +146,6 @@ func main() {
 			}
 		} else {
 			gologger.Info().Msgf("Current interactsh version %v %v", options.Version, updateutils.GetVersionDescription(options.Version, latestVersion))
-		}
-	}
-
-	if cliOptions.Config != defaultConfigLocation {
-		if err := flagSet.MergeConfigFile(cliOptions.Config); err != nil {
-			gologger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 	}
 


### PR DESCRIPTION
When `-config` is provided, goflags' `Parse()` still attempts to read the default config path first, causing errors like:
```
    [FTL] Could not parse options: open /home/USER/.config/interactsh-server/config.yaml: read-only file system
```

This change scans `os.Args` for `-config` before `Parse()` and call `SetConfigFilePath()` so goflags uses the custom path from the start. The post-parse MergeConfigFile/FileExists checks are removed since `Parse()` already performs the same existence check and merge internally.

Applied to both interactsh-server and interactsh-client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration file path detection for both client and server applications. Custom configuration files specified via `-config` or `--config` command-line flags are now properly recognized and loaded. Both the standard flag forms (e.g., `-config=PATH` and `--config=PATH`) are now correctly handled before command-line option processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->