### PR TITLE
feat: Support reduced nonce lengths and subdomain separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ $ interactsh-server -d hackwithautomation.com -cidl 4 -cidn 6
 [DNS] Listening on TCP 157.230.223.165:53
 ```
 
-**Note:** It is important and required to use same length on both side (**client** and **server**), otherwise co-relation will not work.
+**Note:** The client's `cidl` (correlation ID length) must be **>=* the server's configured value, the server truncates longer IDs to its own length. The `cidn` (nonce length) is flexible, the client can use any configured nonce.
 
 ```console
 $ interactsh-client -s hackwithautomation.com -cidl 4 -cidn 6

--- a/pkg/server/dns_server.go
+++ b/pkg/server/dns_server.go
@@ -13,9 +13,10 @@ import (
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
-	"github.com/projectdiscovery/interactsh/pkg/server/acme"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	"gopkg.in/yaml.v3"
+
+	"github.com/projectdiscovery/interactsh/pkg/server/acme"
 )
 
 // DNSServer is a DNS server instance that listens on port 53.
@@ -299,10 +300,34 @@ func toQType(ttype uint16) (rtype string) {
 	return
 }
 
+func (h *DNSServer) storeInteraction(matchedChunk, fullID, qtype, requestMsg, responseMsg, remoteAddr string) {
+	if len(matchedChunk) < h.options.CorrelationIdLength {
+		return
+	}
+	correlationID := matchedChunk[:h.options.CorrelationIdLength]
+	interaction := &Interaction{
+		Protocol:      "dns",
+		UniqueID:      correlationID,
+		FullId:        fullID,
+		QType:         qtype,
+		RawRequest:    requestMsg,
+		RawResponse:   responseMsg,
+		RemoteAddress: remoteAddr,
+		Timestamp:     time.Now(),
+	}
+	data, err := jsoniter.Marshal(interaction)
+	if err != nil {
+		gologger.Warning().Msgf("Could not encode dns interaction: %s\n", err)
+	} else {
+		gologger.Debug().Msgf("DNS Interaction: \n%s\n", string(data))
+		if err := h.options.Storage.AddInteraction(correlationID, data); err != nil {
+			gologger.Warning().Msgf("Could not store dns interaction: %s\n", err)
+		}
+	}
+}
+
 // handleInteraction handles an interaction for the DNS server
 func (h *DNSServer) handleInteraction(domain string, w dns.ResponseWriter, r *dns.Msg, m *dns.Msg) {
-	var uniqueID, fullID string
-
 	requestMsg := r.String()
 	responseMsg := m.String()
 
@@ -348,54 +373,41 @@ func (h *DNSServer) handleInteraction(domain string, w dns.ResponseWriter, r *dn
 	}
 
 	if foundDomain != "" {
+		host, _, _ := net.SplitHostPort(w.RemoteAddr().String())
+		qtype := toQType(r.Question[0].Qtype)
 		if h.options.ScanEverywhere {
+			// slide through request text (single pass, no tiering)
 			chunks := stringsutil.SplitAny(requestMsg, ".\n\t\"'")
 			for _, chunk := range chunks {
-				for part := range stringsutil.SlideWithLength(chunk, h.options.GetIdLength()) {
+				for part := range stringsutil.SlideWithLength(chunk, h.options.getMinIdLength()) {
 					normalizedPart := strings.ToLower(part)
 					if h.options.isCorrelationID(normalizedPart) {
-						uniqueID = normalizedPart
-						fullID = part
+						h.storeInteraction(normalizedPart, part, qtype, requestMsg, responseMsg, host)
 					}
 				}
 			}
 		} else {
+			// match corrID+nonce in same label (higher confidence)
+			var matched bool
 			parts := strings.Split(domain, ".")
-			for i, part := range parts {
-				for partChunk := range stringsutil.SlideWithLength(part, h.options.GetIdLength()) {
+			fullID := h.options.subdomainOf(domain, true)
+			for _, part := range parts {
+				for partChunk := range stringsutil.SlideWithLength(part, h.options.getMinIdLength()) {
 					normalizedPartChunk := strings.ToLower(partChunk)
 					if h.options.isCorrelationID(normalizedPartChunk) {
-						fullID = part
-						if i+1 <= len(parts) {
-							fullID = strings.Join(parts[:i+1], ".")
-						}
-						uniqueID = normalizedPartChunk
+						h.storeInteraction(normalizedPartChunk, fullID, qtype, requestMsg, responseMsg, host)
+						matched = true
 					}
 				}
 			}
-		}
-	}
-
-	if uniqueID != "" {
-		correlationID := uniqueID[:h.options.CorrelationIdLength]
-		host, _, _ := net.SplitHostPort(w.RemoteAddr().String())
-		interaction := &Interaction{
-			Protocol:      "dns",
-			UniqueID:      uniqueID,
-			FullId:        fullID,
-			QType:         toQType(r.Question[0].Qtype),
-			RawRequest:    requestMsg,
-			RawResponse:   responseMsg,
-			RemoteAddress: host,
-			Timestamp:     time.Now(),
-		}
-		data, err := jsoniter.Marshal(interaction)
-		if err != nil {
-			gologger.Warning().Msgf("Could not encode dns interaction: %s\n", err)
-		} else {
-			gologger.Debug().Msgf("DNS Interaction: \n%s\n", string(data))
-			if err := h.options.Storage.AddInteraction(correlationID, data); err != nil {
-				gologger.Warning().Msgf("Could not store dns interaction: %s\n", err)
+			// match bare corrID (no nonce, possibly split corrID and nonce in different subdomain parts)
+			if !matched {
+				for _, part := range parts {
+					normalizedPart := strings.ToLower(part)
+					if len(normalizedPart) == h.options.CorrelationIdLength && h.options.isCorrelationID(normalizedPart) {
+						h.storeInteraction(normalizedPart, fullID, qtype, requestMsg, responseMsg, host)
+					}
+				}
 			}
 		}
 	}

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -171,9 +171,10 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		}
 
 		if h.options.ScanEverywhere {
+			// slide through request text (single pass, no tiering)
 			chunks := stringsutil.SplitAny(reqString, ".\n\t\"'")
 			for _, chunk := range chunks {
-				for part := range stringsutil.SlideWithLength(chunk, h.options.GetIdLength()) {
+				for part := range stringsutil.SlideWithLength(chunk, h.options.getMinIdLength()) {
 					normalizedPart := strings.ToLower(part)
 					if h.options.isCorrelationID(normalizedPart) {
 						h.handleInteraction(r, normalizedPart, part, reqString, respString, host)
@@ -181,16 +182,25 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 				}
 			}
 		} else {
+			// match corrID+nonce in same label (higher confidence)
+			var matched bool
 			parts := strings.Split(r.Host, ".")
-			for i, part := range parts {
-				for partChunk := range stringsutil.SlideWithLength(part, h.options.GetIdLength()) {
+			fullID := h.options.subdomainOf(r.Host, false)
+			for _, part := range parts {
+				for partChunk := range stringsutil.SlideWithLength(part, h.options.getMinIdLength()) {
 					normalizedPartChunk := strings.ToLower(partChunk)
 					if h.options.isCorrelationID(normalizedPartChunk) {
-						fullID := part
-						if i+1 <= len(parts) {
-							fullID = strings.Join(parts[:i+1], ".")
-						}
 						h.handleInteraction(r, normalizedPartChunk, fullID, reqString, respString, host)
+						matched = true
+					}
+				}
+			}
+			// match bare corrID (no nonce, possibly split corrID and nonce in different subdomain parts)
+			if !matched {
+				for _, part := range parts {
+					normalizedPart := strings.ToLower(part)
+					if len(normalizedPart) == h.options.CorrelationIdLength && h.options.isCorrelationID(normalizedPart) {
+						h.handleInteraction(r, normalizedPart, fullID, reqString, respString, host)
 					}
 				}
 			}
@@ -205,12 +215,15 @@ func httpProtocol(r *http.Request) string {
 	return "http"
 }
 
-func (h *HTTPServer) handleInteraction(r *http.Request, uniqueID, fullID, reqString, respString, hostPort string) {
-	correlationID := uniqueID[:h.options.CorrelationIdLength]
+func (h *HTTPServer) handleInteraction(r *http.Request, matchedChunk, fullID, reqString, respString, hostPort string) {
+	if len(matchedChunk) < h.options.CorrelationIdLength {
+		return
+	}
+	correlationID := matchedChunk[:h.options.CorrelationIdLength]
 
 	interaction := &Interaction{
 		Protocol:      httpProtocol(r),
-		UniqueID:      uniqueID,
+		UniqueID:      correlationID,
 		FullId:        fullID,
 		RawRequest:    reqString,
 		RawResponse:   respString,
@@ -390,6 +403,9 @@ func (h *HTTPServer) registerHandler(w http.ResponseWriter, req *http.Request) {
 
 	atomic.AddInt64(&h.options.Stats.Sessions, 1)
 
+	if len(r.CorrelationID) > h.options.CorrelationIdLength {
+		r.CorrelationID = r.CorrelationID[:h.options.CorrelationIdLength]
+	}
 	if err := h.options.Storage.SetIDPublicKey(r.CorrelationID, r.SecretKey, r.PublicKey); err != nil {
 		gologger.Warning().Msgf("Could not set id and public key for %s: %s\n", r.CorrelationID, err)
 		jsonError(w, fmt.Sprintf("could not set id and public key: %s", err), http.StatusBadRequest)
@@ -418,6 +434,9 @@ func (h *HTTPServer) deregisterHandler(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	if len(r.CorrelationID) > h.options.CorrelationIdLength {
+		r.CorrelationID = r.CorrelationID[:h.options.CorrelationIdLength]
+	}
 	if err := h.options.Storage.RemoveID(r.CorrelationID, r.SecretKey); err != nil {
 		gologger.Warning().Msgf("Could not remove id for %s: %s\n", r.CorrelationID, err)
 		jsonError(w, fmt.Sprintf("could not remove id: %s", err), http.StatusBadRequest)
@@ -456,6 +475,9 @@ func (h *HTTPServer) pollHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if len(ID) > h.options.CorrelationIdLength {
+		ID = ID[:h.options.CorrelationIdLength]
+	}
 	data, aesKey, err := h.options.Storage.GetInteractions(ID, secret)
 	if err != nil {
 		gologger.Warning().Msgf("Could not get interactions for %s: %s\n", ID, err)

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -89,7 +89,7 @@ func (ldapServer *LDAPServer) handleBind(w ldap.ResponseWriter, m *ldap.Message)
 func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Message) {
 	atomic.AddUint64(&ldapServer.options.Stats.Ldap, 1)
 
-	var uniqueID, fullID string
+	var matchedChunk, fullID string
 
 	host := m.Client.Addr().String()
 
@@ -116,29 +116,43 @@ func (ldapServer *LDAPServer) handleSearch(w ldap.ResponseWriter, m *ldap.Messag
 	res := ldap.NewSearchResultDoneResponse(ldap.LDAPResultSuccess)
 	w.Write(res)
 
+	var matched bool
 	for _, part := range stringsutil.SplitAny(string(baseObject), "=,") {
 		partChunks := strings.Split(part, ".")
-		for i, partChunk := range partChunks {
-			for scanChunk := range stringsutil.SlideWithLength(partChunk, ldapServer.options.GetIdLength()) {
-				if ldapServer.options.isCorrelationID(scanChunk) {
-					uniqueID = scanChunk
-					fullID = partChunk
-					if i+1 <= len(partChunks) {
-						fullID = strings.Join(partChunks[:i+1], ".")
-					}
-					ldapServer.handleInteraction(uniqueID, fullID, message.String(), host)
+		fullID = ldapServer.options.subdomainOf(part, false)
+		// match corrID+nonce in same label (higher confidence)
+		for _, partChunk := range partChunks {
+			for scanChunk := range stringsutil.SlideWithLength(partChunk, ldapServer.options.getMinIdLength()) {
+				normalizedChunk := strings.ToLower(scanChunk)
+				if ldapServer.options.isCorrelationID(normalizedChunk) {
+					matchedChunk = normalizedChunk
+					ldapServer.handleInteraction(matchedChunk, fullID, message.String(), host)
+					matched = true
+				}
+			}
+		}
+	}
+	// match bare corrID (no nonce, possibly split corrID and nonce in different subdomain parts)
+	if !matched {
+		for _, part := range stringsutil.SplitAny(string(baseObject), "=,") {
+			fullID = ldapServer.options.subdomainOf(part, false)
+			for _, partChunk := range strings.Split(part, ".") {
+				normalizedChunk := strings.ToLower(partChunk)
+				if len(normalizedChunk) == ldapServer.options.CorrelationIdLength && ldapServer.options.isCorrelationID(normalizedChunk) {
+					matchedChunk = normalizedChunk
+					ldapServer.handleInteraction(matchedChunk, fullID, message.String(), host)
 				}
 			}
 		}
 	}
 }
 
-func (ldapServer *LDAPServer) handleInteraction(uniqueID, fullID, reqString, host string) {
-	if uniqueID != "" {
-		correlationID := uniqueID[:ldapServer.options.CorrelationIdLength]
+func (ldapServer *LDAPServer) handleInteraction(matchedChunk, fullID, reqString, host string) {
+	if len(matchedChunk) >= ldapServer.options.CorrelationIdLength {
+		correlationID := matchedChunk[:ldapServer.options.CorrelationIdLength]
 		interaction := &Interaction{
 			Protocol:      "ldap",
-			UniqueID:      uniqueID,
+			UniqueID:      correlationID,
 			FullId:        fullID,
 			RawRequest:    reqString,
 			RemoteAddress: host,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,7 @@ import (
 type Interaction struct {
 	// Protocol for interaction, can contains HTTP/DNS/SMTP,etc.
 	Protocol string `json:"protocol"`
-	// UniqueID is the uniqueID for the subdomain receiving the interaction.
+	// UniqueID is the correlation ID for the interaction.
 	UniqueID string `json:"unique-id"`
 	// FullId is the full path for the subdomain receiving the interaction.
 	FullId string `json:"full-id"`
@@ -142,7 +142,7 @@ func (options *Options) getURLIDComponent(URL string) string {
 
 	var randomID string
 	for _, part := range parts {
-		for scanChunk := range stringsutil.SlideWithLength(part, options.GetIdLength()) {
+		for scanChunk := range stringsutil.SlideWithLength(part, options.getMinIdLength()) {
 			if options.isCorrelationID(scanChunk) {
 				randomID = part
 			}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/projectdiscovery/interactsh/pkg/settings"
+	stringsutil "github.com/projectdiscovery/utils/strings"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +14,216 @@ func TestGetURLIDComponent(t *testing.T) {
 	options := Options{CorrelationIdLength: settings.CorrelationIdLengthDefault, CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault}
 	random := options.getURLIDComponent("c6rj61aciaeutn2ae680cg5ugboyyyyyn.interactsh.com")
 	require.Equal(t, "c6rj61aciaeutn2ae680cg5ugboyyyyyn", random, "could not get correct component")
+}
+
+func TestIsCorrelationID(t *testing.T) {
+	options := Options{CorrelationIdLength: settings.CorrelationIdLengthDefault, CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault}
+
+	t.Run("bare correlation ID (20 chars, valid xid)", func(t *testing.T) {
+		id := xid.New().String()
+		require.Len(t, id, 20)
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 1 char nonce", func(t *testing.T) {
+		id := xid.New().String() + "a"
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 2 char nonce", func(t *testing.T) {
+		id := xid.New().String() + "ab"
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 3 char nonce (minimum)", func(t *testing.T) {
+		id := xid.New().String() + "abc"
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 4 char nonce", func(t *testing.T) {
+		id := xid.New().String() + "abcd"
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 8 char nonce", func(t *testing.T) {
+		id := xid.New().String() + "abcdefgh"
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("corrID + 13 char nonce (default)", func(t *testing.T) {
+		id := xid.New().String() + strings.Repeat("a", 13)
+		require.True(t, options.isCorrelationID(id))
+	})
+
+	t.Run("too short string", func(t *testing.T) {
+		require.False(t, options.isCorrelationID("tooshort"))
+	})
+
+	t.Run("non-xid prefix (contains wxyz)", func(t *testing.T) {
+		// xid only uses [0-9a-v], so 'w', 'x', 'y', 'z' are invalid
+		id := "wxyzwxyzwxyzwxyzwxyz" + strings.Repeat("a", 13)
+		require.False(t, options.isCorrelationID(id))
+	})
+
+	t.Run("non-alphanumeric", func(t *testing.T) {
+		id := xid.New().String() + "abc-def-ghijk"
+		require.False(t, options.isCorrelationID(id))
+	})
+
+	t.Run("sliding window finds embedded ID with minIdLength", func(t *testing.T) {
+		validID := xid.New().String() + "abc" // 23 chars (corrID + 3 char nonce)
+		longer := ".." + validID + ".."        // non-alphanumeric padding prevents spurious matches
+		found := false
+		for chunk := range stringsutil.SlideWithLength(longer, options.getMinIdLength()) {
+			if options.isCorrelationID(chunk) {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "sliding window should find embedded correlation ID")
+	})
+}
+
+func TestTwoTierMatching(t *testing.T) {
+	options := Options{CorrelationIdLength: settings.CorrelationIdLengthDefault, CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault}
+
+	t.Run("tier 1: corrID+nonce in same label", func(t *testing.T) {
+		corrID := xid.New().String()
+		nonce := strings.Repeat("a", 13)
+		domain := corrID + nonce + ".interactsh.com."
+
+		parts := strings.Split(domain, ".")
+		var matches []string
+		for _, part := range parts {
+			for partChunk := range stringsutil.SlideWithLength(part, options.getMinIdLength()) {
+				normalizedPartChunk := strings.ToLower(partChunk)
+				if options.isCorrelationID(normalizedPartChunk) {
+					matches = append(matches, normalizedPartChunk)
+				}
+			}
+		}
+		require.NotEmpty(t, matches, "tier 1 should find corrID+nonce")
+		// Verify correlation ID extraction
+		require.Equal(t, corrID, matches[0][:options.CorrelationIdLength])
+	})
+
+	t.Run("tier 2: bare corrID label (no nonce)", func(t *testing.T) {
+		corrID := xid.New().String()
+		domain := corrID + ".interactsh.com."
+
+		parts := strings.Split(domain, ".")
+		// Tier 1: no matches expected (no label >= minIdLength with valid corrID+nonce)
+		tier1Matched := false
+		for _, part := range parts {
+			for partChunk := range stringsutil.SlideWithLength(part, options.getMinIdLength()) {
+				normalizedPartChunk := strings.ToLower(partChunk)
+				if options.isCorrelationID(normalizedPartChunk) {
+					tier1Matched = true
+				}
+			}
+		}
+		// SlideWithLength emits the full string for short labels, so tier 1 may match bare corrID
+		// Tier 2 is a fallback — test that bare corrID labels are matchable
+		tier2Matched := false
+		for _, part := range parts {
+			normalizedPart := strings.ToLower(part)
+			if len(normalizedPart) == options.CorrelationIdLength && options.isCorrelationID(normalizedPart) {
+				tier2Matched = true
+			}
+		}
+		require.True(t, tier1Matched || tier2Matched, "bare corrID should be matched by at least one tier")
+	})
+
+	t.Run("preference: corrID+nonce matched by tier 1", func(t *testing.T) {
+		corrID := xid.New().String()
+		nonce := strings.Repeat("a", 13)
+		domain := corrID + nonce + ".interactsh.com."
+
+		parts := strings.Split(domain, ".")
+		tier1Matched := false
+		for _, part := range parts {
+			for partChunk := range stringsutil.SlideWithLength(part, options.getMinIdLength()) {
+				normalizedPartChunk := strings.ToLower(partChunk)
+				if options.isCorrelationID(normalizedPartChunk) {
+					tier1Matched = true
+				}
+			}
+		}
+		require.True(t, tier1Matched, "corrID+nonce should be matched by tier 1")
+	})
+
+	t.Run("any nonce length works with default config", func(t *testing.T) {
+		corrID := xid.New().String()
+		for _, nonceLen := range []int{3, 4, 8, 13, 20} {
+			nonce := strings.Repeat("a", nonceLen)
+			domain := corrID + nonce + ".interactsh.com."
+			parts := strings.Split(domain, ".")
+			matched := false
+			for _, part := range parts {
+				for partChunk := range stringsutil.SlideWithLength(part, options.getMinIdLength()) {
+					normalizedPartChunk := strings.ToLower(partChunk)
+					if options.isCorrelationID(normalizedPartChunk) {
+						// Verify the correlation ID is extractable
+						require.Equal(t, corrID, normalizedPartChunk[:options.CorrelationIdLength])
+						matched = true
+					}
+				}
+			}
+			require.True(t, matched, "should match corrID with nonce length %d", nonceLen)
+		}
+	})
+}
+
+func TestSubdomainOf(t *testing.T) {
+	options := Options{
+		CorrelationIdLength:      settings.CorrelationIdLengthDefault,
+		CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault,
+		Domains:                  []string{"interactsh.com"},
+	}
+
+	t.Run("corrID+nonce same label (FQDN)", func(t *testing.T) {
+		result := options.subdomainOf("corrIDnonce.interactsh.com.", true)
+		require.Equal(t, "corrIDnonce", result)
+	})
+
+	t.Run("corrID and nonce dot-separated (FQDN)", func(t *testing.T) {
+		result := options.subdomainOf("corrID.nonce.interactsh.com.", true)
+		require.Equal(t, "corrID.nonce", result)
+	})
+
+	t.Run("nonce before corrID (FQDN)", func(t *testing.T) {
+		result := options.subdomainOf("nonce.corrID.interactsh.com.", true)
+		require.Equal(t, "nonce.corrID", result)
+	})
+
+	t.Run("corrID+nonce same label (HTTP)", func(t *testing.T) {
+		result := options.subdomainOf("corrIDnonce.interactsh.com", false)
+		require.Equal(t, "corrIDnonce", result)
+	})
+
+	t.Run("corrID and nonce dot-separated (HTTP)", func(t *testing.T) {
+		result := options.subdomainOf("corrID.nonce.interactsh.com", false)
+		require.Equal(t, "corrID.nonce", result)
+	})
+
+	t.Run("subdomain server domain", func(t *testing.T) {
+		opts := Options{
+			CorrelationIdLength:      settings.CorrelationIdLengthDefault,
+			CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault,
+			Domains:                  []string{"s.interactsh.com"},
+		}
+		result := opts.subdomainOf("corrID.nonce.s.interactsh.com.", true)
+		require.Equal(t, "corrID.nonce", result)
+	})
+
+	t.Run("no matching domain returns hostname", func(t *testing.T) {
+		result := options.subdomainOf("corrID.nonce.unknown.com", false)
+		require.Equal(t, "corrID.nonce.unknown.com", result)
+	})
+}
+
+func TestURLReflection(t *testing.T) {
+	options := Options{CorrelationIdLength: settings.CorrelationIdLengthDefault, CorrelationIdNonceLength: settings.CorrelationIdNonceLengthDefault}
+	reflection := options.URLReflection("c6rj61aciaeutn2ae680cg5ugboyyyyyn.interactsh.com")
+	require.NotEmpty(t, reflection)
 }

--- a/pkg/server/smtp_server.go
+++ b/pkg/server/smtp_server.go
@@ -80,11 +80,34 @@ func (h *SMTPServer) ListenAndServe(tlsConfig *tls.Config, smtpAlive, smtpsAlive
 	}
 }
 
+func (h *SMTPServer) storeInteraction(matchedChunk, fullID, dataString, from, remoteAddr string) {
+	if len(matchedChunk) < h.options.CorrelationIdLength {
+		return
+	}
+	correlationID := matchedChunk[:h.options.CorrelationIdLength]
+	interaction := &Interaction{
+		Protocol:      "smtp",
+		UniqueID:      correlationID,
+		FullId:        fullID,
+		RawRequest:    dataString,
+		SMTPFrom:      from,
+		RemoteAddress: remoteAddr,
+		Timestamp:     time.Now(),
+	}
+	data, err := jsoniter.Marshal(interaction)
+	if err != nil {
+		gologger.Warning().Msgf("Could not encode smtp interaction: %s\n", err)
+	} else {
+		gologger.Debug().Msgf("%s\n", string(data))
+		if err := h.options.Storage.AddInteraction(correlationID, data); err != nil {
+			gologger.Warning().Msgf("Could not store smtp interaction: %s\n", err)
+		}
+	}
+}
+
 // defaultHandler is a handler for default collaborator requests
 func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []string, data []byte) error {
 	atomic.AddUint64(&h.options.Stats.Smtp, 1)
-
-	var uniqueID, fullID string
 
 	dataString := string(data)
 	gologger.Debug().Msgf("New SMTP request: %s %s %s %s\n", remoteAddr, from, to, dataString)
@@ -121,39 +144,30 @@ func (h *SMTPServer) defaultHandler(remoteAddr net.Addr, from string, to []strin
 	}
 
 	for _, addr := range to {
-		if len(addr) > h.options.GetIdLength() && strings.Contains(addr, "@") {
-			parts := strings.Split(addr[strings.LastIndex(addr, "@")+1:], ".")
-			for i, part := range parts {
-				if h.options.isCorrelationID(part) {
-					uniqueID = part
-					fullID = part
-					if i+1 <= len(parts) {
-						fullID = strings.Join(parts[:i+1], ".")
+		if len(addr) > h.options.getMinIdLength() && strings.Contains(addr, "@") {
+			host, _, _ := net.SplitHostPort(remoteAddr.String())
+			domainPart := addr[strings.LastIndex(addr, "@")+1:]
+			parts := strings.Split(domainPart, ".")
+			fullID := h.options.subdomainOf(domainPart, false)
+			var matched bool
+			// match corrID+nonce in same label (higher confidence)
+			for _, part := range parts {
+				for partChunk := range stringsutil.SlideWithLength(part, h.options.getMinIdLength()) {
+					normalizedPartChunk := strings.ToLower(partChunk)
+					if h.options.isCorrelationID(normalizedPartChunk) {
+						h.storeInteraction(normalizedPartChunk, fullID, dataString, from, host)
+						matched = true
 					}
 				}
 			}
-		}
-	}
-	if uniqueID != "" {
-		host, _, _ := net.SplitHostPort(remoteAddr.String())
-
-		correlationID := uniqueID[:h.options.CorrelationIdLength]
-		interaction := &Interaction{
-			Protocol:      "smtp",
-			UniqueID:      uniqueID,
-			FullId:        fullID,
-			RawRequest:    dataString,
-			SMTPFrom:      from,
-			RemoteAddress: host,
-			Timestamp:     time.Now(),
-		}
-		data, err := jsoniter.Marshal(interaction)
-		if err != nil {
-			gologger.Warning().Msgf("Could not encode smtp interaction: %s\n", err)
-		} else {
-			gologger.Debug().Msgf("%s\n", string(data))
-			if err := h.options.Storage.AddInteraction(correlationID, data); err != nil {
-				gologger.Warning().Msgf("Could not store smtp interaction: %s\n", err)
+			// match bare corrID (no nonce, possibly split corrID and nonce in different subdomain parts)
+			if !matched {
+				for _, part := range parts {
+					normalizedPart := strings.ToLower(part)
+					if len(normalizedPart) == h.options.CorrelationIdLength && h.options.isCorrelationID(normalizedPart) {
+						h.storeInteraction(normalizedPart, fullID, dataString, from, host)
+					}
+				}
 			}
 		}
 	}

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -6,19 +6,43 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/projectdiscovery/interactsh/pkg/settings"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/rs/xid"
 )
 
+// getMinIdLength returns the minimum length of a correlation ID + nonce combined in a single label.
+func (options *Options) getMinIdLength() int {
+	return options.CorrelationIdLength + settings.CorrelationIdNonceLengthMinimum
+}
+
+// isCorrelationID reports whether s could be a correlation ID, optionally followed by a nonce.
+// Accepts bare correlation IDs (len == CorrelationIdLength) and IDs with nonce (len >= CorrelationIdLength).
 func (options *Options) isCorrelationID(s string) bool {
-	if len(s) == options.GetIdLength() && govalidator.IsAlphanumeric(s) {
-		// xid should be 12
-		if options.CorrelationIdLength != 12 {
-			return true
-		} else if _, err := xid.FromString(strings.ToLower(s[:options.CorrelationIdLength])); err == nil {
-			return true
+	if len(s) < options.CorrelationIdLength || !govalidator.IsAlphanumeric(s) {
+		return false
+	}
+	// xid encodes 12 bytes as a 20-char base32hex string; validate the prefix when possible
+	const xidStringLength = 20
+	if options.CorrelationIdLength >= xidStringLength {
+		_, err := xid.FromString(strings.ToLower(s[:xidStringLength]))
+		return err == nil
+	}
+	return true
+}
+
+// subdomainOf returns the subdomain portion of hostname with the server's
+// configured domain stripped. isFQDN should be true for DNS names (trailing dot).
+func (options *Options) subdomainOf(hostname string, isFQDN bool) string {
+	if isFQDN {
+		hostname = strings.TrimSuffix(hostname, ".")
+	}
+	for _, domain := range options.Domains {
+		if stringsutil.HasSuffixI(hostname, "."+domain) {
+			return hostname[:len(hostname)-len(domain)-1]
 		}
 	}
-	return false
+	return hostname
 }
 
 func formatAddress(host string, port int) string {


### PR DESCRIPTION
This change simplifies the interaction storage to only retain the correlation ID, since the nonce is not needed for routing interactions to clients.

The biggest concern in this change is accurately choosing the correlation id. IDs with suffixed nonces are preferred if available, but this change is willing to accept isolated correlationIDs. This allows the correlation id and nonce to be split into different subdomain components (or orders).

This PR is presented as an alternative to #1345 

#1345 provides a minimal fix to support clients able to configure nonce lengths LONGER than the server, but still requires the client to meet at least that minimum length.

This PR makes the server and client nonce lengths fully independent (client can configure any length, or no length, as a subdomain, or a suffix to the correlation id). This offers a lot of flexibility for different use cases without the need to adjust the server configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable correlation-ID detection across DNS, HTTP, LDAP and SMTP with two-tier matching (nonce+bare ID), multi-path scanning, and centralized interaction recording.
  * Refined minimum ID-length logic and improved subdomain extraction and host handling to reduce missed captures.

* **Tests**
  * Expanded coverage for correlation ID validation, two-tier matching, sliding-window detection, and URL reflection.

* **Documentation**
  * Clarified correlation ID vs nonce length expectations in README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->