### PR TITLE
fix: display HTTPS interactions in interactsh-client output

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -227,7 +227,7 @@ func main() {
 				if noFilter || cliOptions.HTTPOnly {
 					fmt.Fprintf(builder, "[%s] Received %s interaction from %s at %s", interaction.FullId, strings.ToUpper(interaction.Protocol), interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05"))
 					if cliOptions.Verbose {
-						fmt.Fprintf(builder, "\n------------\nHTTP Request\n------------\n\n%s\n\n-------------\nHTTP Response\n-------------\n\n%s\n\n", interaction.RawRequest, interaction.RawResponse)
+						fmt.Fprintf(builder, "\n------------\n%s Request\n------------\n\n%s\n\n-------------\n%s Response\n-------------\n\n%s\n\n", strings.ToUpper(interaction.Protocol), interaction.RawRequest, strings.ToUpper(interaction.Protocol), interaction.RawResponse)
 					}
 					writeOutput(outputFile, builder)
 				}

--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -225,9 +225,10 @@ func main() {
 				}
 			case "http", "https":
 				if noFilter || cliOptions.HTTPOnly {
-					fmt.Fprintf(builder, "[%s] Received %s interaction from %s at %s", interaction.FullId, strings.ToUpper(interaction.Protocol), interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05"))
+					proto := strings.ToUpper(interaction.Protocol)
+					fmt.Fprintf(builder, "[%s] Received %s interaction from %s at %s", interaction.FullId, proto, interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05"))
 					if cliOptions.Verbose {
-						fmt.Fprintf(builder, "\n------------\n%s Request\n------------\n\n%s\n\n-------------\n%s Response\n-------------\n\n%s\n\n", strings.ToUpper(interaction.Protocol), interaction.RawRequest, strings.ToUpper(interaction.Protocol), interaction.RawResponse)
+						fmt.Fprintf(builder, "\n------------\n%s Request\n------------\n\n%s\n\n-------------\n%s Response\n-------------\n\n%s\n\n", proto, interaction.RawRequest, proto, interaction.RawResponse)
 					}
 					writeOutput(outputFile, builder)
 				}


### PR DESCRIPTION
## Summary
- Commit aab1b78 introduced `httpProtocol()` to differentiate HTTP vs HTTPS on the server, setting `protocol` to `"https"` for TLS connections
- The client display switch in `cmd/interactsh-client/main.go` only matched `case "http":`, silently dropping all HTTPS interactions
- Added `"https"` to the case match and dynamically render the protocol name (HTTP/HTTPS) in the output

## Test plan
- [x] Start interactsh-server with TLS enabled
- [x] Start interactsh-client, curl the generated URL over HTTPS
- [x] Verify `Received HTTPS interaction` appears in client output
- [x] Verify HTTP interactions still display correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CLI interaction output formatting to display protocol-specific headers. Headers now show the actual protocol used (HTTP or HTTPS) instead of generic labels, providing clearer information in both standard and verbose output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->