### PR TITLE
fix: display HTTPS interactions in client output

### DIFF
--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -223,7 +223,7 @@ func main() {
 					}
 					writeOutput(outputFile, builder)
 				}
-			case "http":
+			case "http", "https":
 				if noFilter || cliOptions.HTTPOnly {
 					fmt.Fprintf(builder, "[%s] Received HTTP interaction from %s at %s", interaction.FullId, interaction.RemoteAddress, interaction.Timestamp.Format("2006-01-02 15:04:05"))
 					if cliOptions.Verbose {


### PR DESCRIPTION
## Summary

Since aab1b78 (`fix: differentiate HTTP vs HTTPS protocol in interactions`), the server returns `"https"` as the protocol for TLS interactions. The client's switch statement in `main.go` only handles `case "http":`, so HTTPS interactions are silently dropped from the output.

This is the companion fix to projectdiscovery/interactsh-web#238 which addresses the same issue on the web client side.

- Add `"https"` to the `"http"` case in the client output switch

## Test plan

- [ ] Register a client against a v1.3.1+ server
- [ ] Send an HTTPS request to the generated callback URL
- [ ] Verify the interaction appears in the client output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTPS protocol interactions are now processed identically to HTTP interactions in CLI output. Both protocol types will undergo the same filtering checks, output formatting, and detailed request/response rendering rules, providing consistent and comprehensive behavior across all HTTP-based interaction types reported in the command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->