### PR TITLE
fix(server): strip port before wildcard host match

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -144,8 +144,12 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 
 		// if root-tld is enabled stores any interaction towards the main domain
 		if h.options.RootTLD {
+			requestHost := r.Host
+			if host, _, err := net.SplitHostPort(r.Host); err == nil {
+				requestHost = host
+			}
 			for _, domain := range h.options.Domains {
-				if h.options.RootTLD && stringsutil.HasSuffixI(r.Host, domain) {
+				if h.options.RootTLD && stringsutil.HasSuffixI(requestHost, domain) {
 					ID := domain
 					host, _, _ := net.SplitHostPort(r.RemoteAddr)
 					interaction := &Interaction{

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -35,6 +35,39 @@ func TestHttpProtocol(t *testing.T) {
 	})
 }
 
+func TestWildcardHTTPSRequestWithPortIsStoredAsRootTLDInteraction(t *testing.T) {
+	store := newTestStorage(t)
+	require.NoError(t, store.SetID("example.com"))
+
+	h, err := NewHTTPServer(&Options{
+		Domains:                  []string{"example.com"},
+		Storage:                  store,
+		RootTLD:                  true,
+		OriginURL:                "*",
+		CorrelationIdLength:      3,
+		CorrelationIdNonceLength: 3,
+		Stats:                    &Metrics{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "https://abc123.example.com:443/", nil)
+	req.Host = "abc123.example.com:443"
+	w := httptest.NewRecorder()
+
+	h.tlsserver.Handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	interactions, err := store.GetInteractionsWithIdForConsumer("example.com", "consumer")
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+
+	var interaction Interaction
+	require.NoError(t, jsoniter.UnmarshalFromString(interactions[0], &interaction))
+	require.Equal(t, "https", interaction.Protocol)
+	require.Equal(t, "abc123.example.com:443", interaction.UniqueID)
+	require.Equal(t, "abc123.example.com:443", interaction.FullId)
+}
+
 func TestWriteResponseFromDynamicRequest(t *testing.T) {
 	t.Run("status", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://example.com/?status=404", nil)


### PR DESCRIPTION
Wildcard root-TLD logging matched configured
domains against the raw Host header. HTTPS
requests commonly include the default port in Host,
such as "foo.bar.com:443", which prevented the
suffix match from recognizing the configured
domain and skipped interaction storage.

Strip a syntactic Host port only for the domain
match while preserving the original Host value in
the recorded interaction.

Fixes #1387