### PR TITLE
Fix Responder Docker image build and startup for modern Responder

### DIFF
--- a/cmd/interactsh-server/Dockerfile
+++ b/cmd/interactsh-server/Dockerfile
@@ -1,11 +1,32 @@
-FROM python:3.8-alpine as compile
+FROM python:3.11-slim-bookworm
 WORKDIR /opt
-RUN apk add --no-cache git gcc musl-dev python3-dev libffi-dev openssl-dev cargo
-RUN python3 -m pip install virtualenv
-RUN virtualenv -p python venv
+
+# Build deps + runtime networking tools Responder shells out to (ip/ifconfig)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git gcc python3-dev libffi-dev libssl-dev \
+        iproute2 net-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip virtualenv \
+    && virtualenv -p python3 /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN git clone --depth 1 https://github.com/SecureAuthCorp/impacket.git
-RUN python3 -m pip install impacket/
-RUN git clone --depth 1 https://github.com/lgandx/Responder.git
-RUN python3 -m pip install netifaces
-ENTRYPOINT ["python3","/opt/Responder/Responder.py","-I","eth0"]
+
+# Impacket (repo moved SecureAuthCorp -> fortra)
+RUN git clone --depth 1 https://github.com/fortra/impacket.git \
+    && python3 -m pip install --no-cache-dir ./impacket \
+    && rm -rf impacket
+
+# Responder deps: upstream pins netifaces, which fails to build on modern
+# toolchains; netifaces-plus is a drop-in replacement (same import name).
+RUN git clone --depth 1 https://github.com/lgandx/Responder.git \
+    && python3 -m pip install --no-cache-dir aioquic netifaces-plus
+
+# Keep HTTP/HTTPS off so Responder does not fight interactsh on 80/443
+# when someone runs with --network host.
+RUN sed -i \
+        -e 's/^HTTP     = On/HTTP     = Off/' \
+        -e 's/^HTTPS    = On/HTTPS    = Off/' \
+        /opt/Responder/Responder.conf
+
+WORKDIR /opt/Responder
+ENTRYPOINT ["/opt/venv/bin/python3", "/opt/Responder/Responder.py", "-I", "eth0"]

--- a/cmd/interactsh-server/Dockerfile
+++ b/cmd/interactsh-server/Dockerfile
@@ -21,12 +21,13 @@ RUN git clone --depth 1 https://github.com/fortra/impacket.git \
 RUN git clone --depth 1 https://github.com/lgandx/Responder.git \
     && python3 -m pip install --no-cache-dir aioquic netifaces-plus
 
-# Keep HTTP/HTTPS off so Responder does not fight interactsh on 80/443
+# Keep HTTP/HTTPS/DNS off so Responder does not fight interactsh on those ports
 # when someone runs with --network host.
 RUN sed -i \
         -e 's/^HTTP     = On/HTTP     = Off/' \
         -e 's/^HTTPS    = On/HTTPS    = Off/' \
+        -e 's/^DNS      = On/DNS      = Off/' \
         /opt/Responder/Responder.conf
 
 WORKDIR /opt/Responder
-ENTRYPOINT ["/opt/venv/bin/python3", "/opt/Responder/Responder.py", "-I", "eth0"]
+ENTRYPOINT ["/opt/venv/bin/python3", "/opt/Responder/Responder.py", "-I", "eth0", "-v"]

--- a/pkg/server/responder_server.go
+++ b/pkg/server/responder_server.go
@@ -15,9 +15,14 @@ import (
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
-var responderMonitorList map[string]string = map[string]string{
-	// search term : extract after
+// Patterns taken from Responder SaveToDb() output:
+//   [SMB] NTLMv2-SSP Hash     : user::domain:...
+// Also accept shorter variants written to per-client dump files.
+var responderMonitorList = map[string]string{
 	"NTLMv2-SSP Hash": "NTLMv2-SSP Hash     : ",
+	"NTLMv1-SSP Hash": "NTLMv1-SSP Hash     : ",
+	"NTLMv2 Hash":     "NTLMv2 Hash     : ",
+	"NTLMv1 Hash":     "NTLMv1 Hash     : ",
 }
 
 // ResponderServer is a Responder wrapper server instance
@@ -28,7 +33,7 @@ type ResponderServer struct {
 	tmpFolder string
 }
 
-// NewResponderServer returns a new SMB server.
+// NewResponderServer returns a new Responder server.
 func NewResponderServer(options *Options) (*ResponderServer, error) {
 	return &ResponderServer{options: options}, nil
 }
@@ -80,51 +85,115 @@ func (h *ResponderServer) ListenAndServe(responderAlive chan bool) error {
 		case <-time.After(1 * time.Second):
 		}
 	}
-	fw, err := filewatcher.New(filewatcher.Options{
-		Interval: time.Duration(5 * time.Second),
-		File:     outputFile,
-	})
-	if err != nil {
-		return err
-	}
 
-	ch, err := fw.Watch()
-	if err != nil {
-		return err
-	}
+	out := make(chan string, 64)
+	go h.watchFile(outputFile, out)
+	// Responder always writes fullhash lines to per-client files under logs/,
+	// even when SessionLog formatting changes.
+	go h.watchHashDumpFiles(out)
 
-	// This fetches the content at each change.
 	go func() {
-		for data := range ch {
-			for searchTerm, extractAfter := range responderMonitorList {
-				if strings.Contains(data, searchTerm) {
-					responderData, err := stringsutil.After(data, extractAfter)
-					if err != nil {
-						gologger.Warning().Msgf("Could not get responder interaction: %s\n", err)
-						continue
-					}
-
-					// Correlation id doesn't apply here, we skip encryption
-					interaction := &Interaction{
-						Protocol:   "responder",
-						RawRequest: responderData,
-						Timestamp:  time.Now(),
-					}
-					data, err := jsoniter.Marshal(interaction)
-					if err != nil {
-						gologger.Warning().Msgf("Could not encode responder interaction: %s\n", err)
-					} else {
-						gologger.Debug().Msgf("Responder Interaction: \n%s\n", string(data))
-						if err := h.options.Storage.AddInteractionWithId(h.options.Token, data); err != nil {
-							gologger.Warning().Msgf("Could not store dns interaction: %s\n", err)
-						}
-					}
-				}
-			}
+		for data := range out {
+			h.handleResponderLogLine(data)
 		}
 	}()
 
 	return <-done
+}
+
+func (h *ResponderServer) watchFile(path string, out chan<- string) {
+	fw, err := filewatcher.New(filewatcher.Options{
+		Interval: 2 * time.Second,
+		File:     path,
+	})
+	if err != nil {
+		gologger.Warning().Msgf("Could not watch responder log %s: %s\n", path, err)
+		return
+	}
+	ch, err := fw.Watch()
+	if err != nil {
+		gologger.Warning().Msgf("Could not start responder log watcher %s: %s\n", path, err)
+		return
+	}
+	for data := range ch {
+		out <- data
+	}
+}
+
+func (h *ResponderServer) watchHashDumpFiles(out chan<- string) {
+	seen := make(map[string]struct{})
+	for {
+		entries, err := os.ReadDir(h.tmpFolder)
+		if err == nil {
+			for _, entry := range entries {
+				name := entry.Name()
+				if entry.IsDir() || !strings.HasSuffix(name, ".txt") {
+					continue
+				}
+				// e.g. SMB-NTLMv2-SSP-1.2.3.4.txt
+				if !strings.Contains(name, "NTLM") && !strings.Contains(name, "ClearText") {
+					continue
+				}
+				path := filepath.Join(h.tmpFolder, name)
+				content, err := os.ReadFile(path)
+				if err != nil {
+					continue
+				}
+				for _, line := range strings.Split(string(content), "\n") {
+					line = strings.TrimSpace(line)
+					if line == "" {
+						continue
+					}
+					key := name + ":" + line
+					if _, ok := seen[key]; ok {
+						continue
+					}
+					seen[key] = struct{}{}
+					out <- line
+				}
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (h *ResponderServer) handleResponderLogLine(data string) {
+	for searchTerm, extractAfter := range responderMonitorList {
+		if strings.Contains(data, searchTerm) {
+			responderData, err := stringsutil.After(data, extractAfter)
+			if err != nil {
+				gologger.Warning().Msgf("Could not get responder interaction: %s\n", err)
+				continue
+			}
+			h.storeResponderInteraction(strings.TrimSpace(responderData))
+			return
+		}
+	}
+
+	// Per-client dump files contain the raw fullhash only (no "Hash :" prefix).
+	if strings.Count(data, ":") >= 3 && (strings.Contains(data, "::") || strings.Contains(strings.ToUpper(data), "NTLM")) {
+		h.storeResponderInteraction(data)
+	}
+}
+
+func (h *ResponderServer) storeResponderInteraction(responderData string) {
+	if responderData == "" {
+		return
+	}
+	interaction := &Interaction{
+		Protocol:   "responder",
+		RawRequest: responderData,
+		Timestamp:  time.Now(),
+	}
+	data, err := jsoniter.Marshal(interaction)
+	if err != nil {
+		gologger.Warning().Msgf("Could not encode responder interaction: %s\n", err)
+		return
+	}
+	gologger.Info().Msgf("Responder Interaction: %s\n", responderData)
+	if err := h.options.Storage.AddInteractionWithId(h.options.Token, data); err != nil {
+		gologger.Warning().Msgf("Could not store responder interaction: %s\n", err)
+	}
 }
 
 func (h *ResponderServer) Close() {

--- a/pkg/server/responder_server.go
+++ b/pkg/server/responder_server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,25 +39,46 @@ func (h *ResponderServer) ListenAndServe(responderAlive chan bool) error {
 	defer func() {
 		responderAlive <- false
 	}()
-	tmpFolder, err := os.MkdirTemp("", "")
+	tmpFolder, err := os.MkdirTemp("", "interactsh-responder-")
 	if err != nil {
 		return err
 	}
 	h.tmpFolder = tmpFolder
-	// execute dockerized responder
-	cmdLine := "docker run -p 137:137/udp -p  138:138/udp -p 389:389 -p 1433:1433 -p 1434:1434/udp -p 135:135 -p 139:139 -p 445:445 -p 21:21 -p 3141:3141 -p 110:110 -p 3128:3128 -p 5355:5355/udp -v " + h.tmpFolder + ":/opt/Responder/logs --rm interactsh:latest"
+
+	// interactsh always binds LDAP on LdapPort (default 389). Only publish
+	// container 389 when LDAP was moved off that port (e.g. -ldap-port 10389).
+	ports := "-p 137:137/udp -p 138:138/udp -p 1433:1433 -p 1434:1434/udp -p 135:135 -p 139:139 -p 445:445 -p 21:21 -p 3141:3141 -p 110:110 -p 3128:3128 -p 5355:5355/udp"
+	if h.options.LdapPort != 389 {
+		ports = "-p 137:137/udp -p 138:138/udp -p 389:389 -p 1433:1433 -p 1434:1434/udp -p 135:135 -p 139:139 -p 445:445 -p 21:21 -p 3141:3141 -p 110:110 -p 3128:3128 -p 5355:5355/udp"
+	}
+	cmdLine := "docker run " + ports + " -v " + h.tmpFolder + ":/opt/Responder/logs --rm interactsh:latest"
 	args := strings.Fields(cmdLine)
-	h.cmd = exec.Command(args[0], args[1:]...)
+	h.cmd = exec.Command(args[0], args[1:]...) //nolint:gosec
+	h.cmd.Stdout = os.Stdout
+	h.cmd.Stderr = os.Stderr
 	err = h.cmd.Start()
 	if err != nil {
+		gologger.Error().Msgf("Could not start responder docker container: %s\n", err)
 		return err
 	}
+	gologger.Info().Msgf("Responder container started (pid %d), waiting for session log...\n", h.cmd.Process.Pid)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.cmd.Wait()
+	}()
 
 	// watch output file
 	outputFile := filepath.Join(h.tmpFolder, "Responder-Session.log")
-	// wait until the file is created
 	for !fileutil.FileExists(outputFile) {
-		time.Sleep(1 * time.Second)
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("responder container exited before creating %s: %w", outputFile, err)
+			}
+			return fmt.Errorf("responder container exited before creating %s", outputFile)
+		case <-time.After(1 * time.Second):
+		}
 	}
 	fw, err := filewatcher.New(filewatcher.Options{
 		Interval: time.Duration(5 * time.Second),
@@ -102,11 +124,13 @@ func (h *ResponderServer) ListenAndServe(responderAlive chan bool) error {
 		}
 	}()
 
-	return h.cmd.Wait()
+	return <-done
 }
 
 func (h *ResponderServer) Close() {
-	_ = h.cmd.Process.Kill()
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Process.Kill()
+	}
 	if fileutil.FolderExists(h.tmpFolder) {
 		_ = os.RemoveAll(h.tmpFolder)
 	}


### PR DESCRIPTION
## Summary
- Rebuild the Responder image on Python 3.11 slim with current deps (`aioquic`, `netifaces-plus`, `iproute2`/`net-tools`, fortra/impacket) so `docker build -t interactsh` works against modern Responder.
- Avoid publishing host port 389 when interactsh LDAP already owns it; stream container logs and fail fast if the container exits before creating `Responder-Session.log`.

## Test plan
- [ ] `docker build -t interactsh cmd/interactsh-server`
- [ ] `docker run --rm -v /tmp/responder-logs:/opt/Responder/logs interactsh:latest` shows the Responder banner and stays running; `/tmp/responder-logs/Responder-Session.log` is created
- [ ] `interactsh-server -responder -ldap-port 10389 -d localhost` (or equivalent) starts without Responder immediately stopping


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responder server startup reliability by waiting for the session log with early-exit detection if the container stops.
  * Enhanced capturing of responder interactions from session and per-client dump logs.
  * Improved shutdown handling to safely stop even when the process was not fully initialized.
  * Added/extended support for alternate LDAP port publishing behavior.
* **Chores**
  * Updated the responder container environment for better OS/network compatibility.
  * Disabled container HTTP, HTTPS, and DNS services for tighter runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->