### PR TITLE
bump to Go 1.25 (and run go fix) and to Alpine 3.23.5

### DIFF
--- a/.github/docker/client/Dockerfile
+++ b/.github/docker/client/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.21.0-alpine AS builder
+FROM golang:1.25.0-alpine AS builder
 RUN apk add --no-cache git build-base gcc musl-dev
 WORKDIR /app
 COPY . /app
@@ -7,7 +7,7 @@ RUN go mod download
 RUN go build ./cmd/interactsh-client
 
 # Release
-FROM alpine:3.18.3
+FROM alpine:3.23.5
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=builder /app/interactsh-client /usr/local/bin/

--- a/.github/docker/server/Dockerfile
+++ b/.github/docker/server/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.21.0-alpine AS builder
+FROM golang:1.25.0-alpine AS builder
 RUN apk add --no-cache git build-base gcc musl-dev
 WORKDIR /app
 COPY . /app
@@ -8,7 +8,7 @@ RUN go build ./cmd/interactsh-server
 
 
 # Release
-FROM alpine:3.18.3
+FROM alpine:3.23.5
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates python3 libffi curl \
     && apk add --no-cache --virtual .build-deps python3-dev py3-pip py3-wheel libffi-dev build-base \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v4
         with: 
-          go-version: 1.21.x
+          go-version: 1.25.x
       - name: "Create release on GitHub"
         uses: goreleaser/goreleaser-action@v4
         with: 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
       
       - name: release test
         uses: goreleaser/goreleaser-action@v4

--- a/cmd/interactsh-client/main.go
+++ b/cmd/interactsh-client/main.go
@@ -299,7 +299,7 @@ func main() {
 
 func generatePayloadURL(numberOfPayloads int, client *client.Client) []string {
 	interactshURLs := make([]string, numberOfPayloads)
-	for i := 0; i < numberOfPayloads; i++ {
+	for i := range numberOfPayloads {
 		interactshURLs[i] = client.URL()
 	}
 	return interactshURLs

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/projectdiscovery/interactsh
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.0
 
 require (
 	git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -624,7 +624,7 @@ func (c *Client) performRegistration(serverURL string, payload []byte) error {
 		data, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("could not register to server: %s", string(data))
 	}
-	response := make(map[string]interface{})
+	response := make(map[string]any)
 	if err := jsoniter.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return errkit.Wrap(err, "could not register to server")
 	}

--- a/pkg/server/ftp_server.go
+++ b/pkg/server/ftp_server.go
@@ -141,8 +141,8 @@ func (h *FTPServer) recordInteraction(remoteAddress, data string) {
 	}
 }
 
-func (h *FTPServer) Print(sessionID string, message interface{})              {}
-func (h *FTPServer) Printf(sessionID string, format string, v ...interface{}) {}
+func (h *FTPServer) Print(sessionID string, message any)              {}
+func (h *FTPServer) Printf(sessionID string, format string, v ...any) {}
 func (h *FTPServer) PrintCommand(sessionID string, command string, params string) {
 	h.Print(sessionID, fmt.Sprintf("%s %s", command, params))
 }

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -126,9 +127,7 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 		resp, _ := httputil.DumpResponse(rec.Result(), true)
 		respString := string(resp)
 
-		for k, v := range rec.Header() {
-			w.Header()[k] = v
-		}
+		maps.Copy(w.Header(), rec.Header())
 		data := rec.Body.Bytes()
 
 		w.WriteHeader(rec.Result().StatusCode)
@@ -507,7 +506,7 @@ func jsonBody(w http.ResponseWriter, key, value string, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(code)
-	_ = jsoniter.NewEncoder(w).Encode(map[string]interface{}{key: value})
+	_ = jsoniter.NewEncoder(w).Encode(map[string]any{key: value})
 }
 
 func jsonError(w http.ResponseWriter, err string, code int) {

--- a/pkg/server/ldap_server.go
+++ b/pkg/server/ldap_server.go
@@ -387,7 +387,7 @@ func (ldapServer *LDAPServer) handleExtended(w ldap.ResponseWriter, m *ldap.Mess
 	}
 }
 
-func (ldapServer *LDAPServer) handleLog(host string, f string, v ...interface{}) {
+func (ldapServer *LDAPServer) handleLog(host string, f string, v ...any) {
 	// just discard logs if logger is disabled
 	if !ldapServer.WithLogger {
 		return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -118,7 +118,7 @@ type Options struct {
 	Certificates []tls.Certificate
 	CertFiles    []acme.CertificateFiles
 }
-type OnResultCallback func(out interface{})
+type OnResultCallback func(out any)
 
 func (options *Options) GetIdLength() int {
 	return options.CorrelationIdLength + options.CorrelationIdNonceLength

--- a/pkg/storage/roundtrip_test.go
+++ b/pkg/storage/roundtrip_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
 )
@@ -105,7 +105,7 @@ func TestFullRoundTripInMemory(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and store 3 DNS interactions (like dns_server.go does)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		inter := &interaction{
 			Protocol:      "dns",
 			UniqueID:      "abc123def456ghi",
@@ -158,7 +158,7 @@ func TestFullRoundTripDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and store 3 DNS interactions
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		inter := &interaction{
 			Protocol:      "dns",
 			UniqueID:      "abc123def456ghi",

--- a/pkg/storage/storagedb.go
+++ b/pkg/storage/storagedb.go
@@ -282,7 +282,7 @@ func (s *StorageDB) GetInteractionsWithIdForConsumer(id, consumerID string) ([]s
 			}
 			return nil, err
 		}
-		for _, d := range bytes.Split(raw, []byte("\n")) {
+		for d := range bytes.SplitSeq(raw, []byte("\n")) {
 			if len(d) > 0 {
 				allData = append(allData, string(d))
 			}
@@ -387,7 +387,7 @@ func (s *StorageDB) applyTrim(value *CorrelationData, id string, trimCount int) 
 			return
 		}
 		var allData []string
-		for _, d := range bytes.Split(raw, []byte("\n")) {
+		for d := range bytes.SplitSeq(raw, []byte("\n")) {
 			if len(d) > 0 {
 				allData = append(allData, string(d))
 			}
@@ -418,7 +418,7 @@ func (s *StorageDB) dataLen(value *CorrelationData, id string) int {
 			return 0
 		}
 		count := 0
-		for _, d := range bytes.Split(raw, []byte("\n")) {
+		for d := range bytes.SplitSeq(raw, []byte("\n")) {
 			if len(d) > 0 {
 				count++
 			}
@@ -479,7 +479,7 @@ func (s *StorageDB) getInteractions(correlationData *CorrelationData, id string)
 			return nil, err
 		}
 		var dataString []string
-		for _, d := range bytes.Split(data, []byte("\n")) {
+		for d := range bytes.SplitSeq(data, []byte("\n")) {
 			if len(d) == 0 {
 				continue
 			}

--- a/pkg/storage/storagedb_test.go
+++ b/pkg/storage/storagedb_test.go
@@ -128,7 +128,7 @@ func BenchmarkCacheParallelOther(b *testing.B) {
 }
 
 func doStuffWithOtherCache(cache cache.Cache) {
-	for i := 0; i < 1e2; i++ {
+	for i := range int(1e2) {
 		cache.Put(strconv.Itoa(i), "test")
 		_, _ = cache.GetIfPresent(strconv.Itoa(i))
 	}
@@ -347,7 +347,7 @@ func TestSlidingEvictionStrategy(t *testing.T) {
 	require.True(t, ok)
 
 	// Still present after original TTL due to sliding window
-	time.Sleep(testTTL / 2 + smallDelay)
+	time.Sleep(testTTL/2 + smallDelay)
 	_, ok = mem.cache.GetIfPresent("test-sliding")
 	require.True(t, ok)
 
@@ -372,7 +372,7 @@ func TestFixedEvictionStrategy(t *testing.T) {
 	require.True(t, ok)
 
 	// Should be expired after full TTL despite access
-	time.Sleep(testTTL / 2 + 10 * time.Millisecond)
+	time.Sleep(testTTL/2 + 10*time.Millisecond)
 	_, ok = mem.cache.GetIfPresent("test-fixed")
 	require.False(t, ok)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated the project to require Go 1.25.
  * Updated container build and runtime images to newer Go and Alpine versions.

* **Performance**
  * Improved disk-backed data processing to reduce unnecessary intermediate allocations.

* **Maintenance**
  * Adopted modern Go syntax and standardized type usage throughout the application.
  * Preserved existing payload generation, logging, response handling, storage behavior, and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->